### PR TITLE
Pdf script perms fixes

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -547,10 +547,13 @@ def create_pdf(conn, scriptParams):
         link.parent = ImageI(iid, False)
         link.child = fileAnn._obj
         links.append(link)
-    print len(links)
     if len(links) > 0:
-        links = conn.getUpdateService().saveAndReturnArray(
-            links, conn.SERVICE_OPTS)
+        # Don't want to fail at this point due to strange permissions combo
+        try:
+            links = conn.getUpdateService().saveAndReturnArray(
+                links, conn.SERVICE_OPTS)
+        except:
+            print "Failed to attach figure: %s to images %s" % (fileAnn, imageIds)
 
     return fileAnn
 


### PR DESCRIPTION
Fixes a couple of issues when images in a figure are in different groups:
- Adding Thumbnails to the figure happens with setOmeroGroup(-1) to make sure all are accessible.
- We wrap the saving of FileAnntationLinks in a try/except, in case some of the images are in a different group or can't be annotated for some reason.
