### PR TITLE
Fix jekyll errors building Figure website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 name: Your New Jekyll Site
 markdown: kramdown
 highlighter: pygments
+
 baseurl: /figure

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 name: Your New Jekyll Site
-markdown: redcarpet
-pygments: true
+markdown: kramdown
+highlighter: pygments
 baseurl: /figure


### PR DESCRIPTION
This updates the markdown support for building the figure website withe jekyll and gh-pages.

Hopefully staging should still look identical with this PR included although because the baseurl is different on the main branch, this change may need to be opened manually against the other branch.

I got some funny errors when I had it built locally, don't know if you have any ideas what these are about @will-moore?:
[2016-10-10 16:53:19] ERROR `/figure/css/pygment_trac.css' not found.
[2016-10-10 16:53:20] ERROR `/favicon.ico' not found.
[2016-10-10 16:53:20] ERROR `/apple-touch-icon-precomposed.png' not found.
[2016-10-10 16:53:20] ERROR `/apple-touch-icon.png' not found.
[2016-10-10 16:53:23] ERROR `/figure/css/pygment_trac.css' not found.
[2016-10-10 16:53:25] ERROR `/figure/css/pygment_trac.css' not found.

