### PR TITLE
Fix highlighter to gh-pages supported one

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: Your New Jekyll Site
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 
 baseurl: /figure


### PR DESCRIPTION
Although I fixed the jekyll build as my local installation instructed, it seems gh-pages does not support pygments and we got an error for the website build when the live site was updated. This should fix it without altering the appearance of the site, as it's apparently what gh-pages is using now anyway.