### PR TITLE
Missing channel_slider_template.html from PR #166

### DIFF
--- a/src/templates/channel_slider_template.html
+++ b/src/templates/channel_slider_template.html
@@ -1,0 +1,21 @@
+
+ <div class="clearfix" style="position: relative">
+    <span class="ch_start">
+        <input type="number" data-window="start"
+        <% if (startsNotEqual) { %>
+            title="Average: <%= startAvg %> (selected images have different start values)"
+            style="color: #ccc;"
+        <% } %>
+        data-idx="<%=idx%>" style="width: 40px" value="<%= startAvg %>" max="<%= endAvg %>">
+    </span>
+    <div class="ch_slider" style="background-color:#<%=color%>" aria-disabled="false">
+    </div>
+    <span class="ch_end">
+        <input type="number" data-window="end"
+        <% if (endsNotEqual) { %>
+            title="Average: <%= endAvg %> (selected images have different end values)"
+            style="color: #ccc;"
+        <% } %>
+        data-idx="<%=idx%>" value="<%= endAvg %>" min="<%= startAvg %>">
+    </span>
+</div>


### PR DESCRIPTION
This adds the missing ```channel_slider_template.html``` from #166.

Noticed by @bramalingam.
It wasn't picked up before because the compiled template was included in templates.js until recently.

To test:
 - Check that channel sliders appear and are working normally, as described in #166.