### PR TITLE
Fix label delete

### DIFF
--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -430,6 +430,8 @@
                 key = $form.attr('data-key'),
                 deleteMap = {};
 
+            // escape the key to handle 'single' and "double" quotes
+            key = _.escape(key);
             deleteMap[key] = false;
 
             this.models.forEach(function(m){


### PR DESCRIPTION
Fixes the deletion of labels that contain unescaped characters, e.g. single quotation marks ``` ' ```.

To test, create, labels with various escaped characters in ``` < > ' " ```.
Check you can update these labels (change text or color etc) and delete them.