### PR TITLE
Slider bugfixes

### DIFF
--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -711,7 +711,7 @@
         display: inline-block;
     }
 
-    .lutBg {
+    .lutBg, .ch_slider .ui-slider-range {
         /* NB: when updating png, consider using different name to avoid cache */
         background-image: url('../images/luts_10.png');   /* each lut is 10px high */
         background-size: 100% 1850px;  /* height is stretched 5x (50px per LUT) */

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -843,7 +843,7 @@
                             </button>
                         </div>
                     </div>
-                    <div class='clearfix' style="padding-bottom:3px"></div>
+                    <div class='clearfix' style="padding-bottom:13px"></div>
                     <div id="channel_sliders"></div>
                     <div class='clearfix'></div>
                     <div class='tab-footer'>

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -106,6 +106,7 @@ var ChannelSliderView = Backbone.View.extend({
                 var min = mins.reduce(reduceFn(Math.min), 9999);
                 var max = maxs.reduce(reduceFn(Math.max), -9999);
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
+                var lutBgPos = FigureLutPicker.getLutBackgroundPosition(color);
                 if (color == "FFFFFF") color = "ccc";  // white slider would be invisible
 
                 // Make sure slider range is increased if needed to include current values
@@ -134,7 +135,9 @@ var ChannelSliderView = Backbone.View.extend({
                             m.save_channel_window(chIdx, {'start': ui.values[0], 'end': ui.values[1]});
                         });
                     }
-                });
+                })
+                // Need to add background style to newly created div.ui-slider-range
+                .children('.ui-slider-range').css('background-position', lutBgPos)
             }.bind(this));
         return this;
     }

--- a/src/templates/channel_slider_template.html
+++ b/src/templates/channel_slider_template.html
@@ -8,7 +8,7 @@
         <% } %>
         data-idx="<%=idx%>" style="width: 40px" value="<%= startAvg %>" max="<%= endAvg %>">
     </span>
-    <div class="ch_slider" style="background-color:#<%=color%>" aria-disabled="false">
+    <div class="ch_slider" style="background-color:#ddd; background-color:#<%=color%>" aria-disabled="false">
     </div>
     <span class="ch_end">
         <input type="number" data-window="end"


### PR DESCRIPTION
Fix the display of Timestamp and LUT background for channel sliders.

Previously, timestamp label (for movies with timestamp info) was overlapped by the channel sliders and the channel sliders weren't showing LUT background correctly.

See before and after shots:

![screen shot 2017-03-31 at 15 17 25](https://cloud.githubusercontent.com/assets/900055/24554399/4c7f95d4-1625-11e7-8b1e-df677584cdb4.png)

![screen shot 2017-03-31 at 15 16 42](https://cloud.githubusercontent.com/assets/900055/24554406/51638e8e-1625-11e7-966c-7830b6135d4c.png)

To test:
 - Find an image with timestamp info. Check that label is not obscured.
 - Test display of LUTs on channel sliders.