### PR TITLE
Markdown labels

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1454,7 +1454,6 @@ class TiffExport(FigureExport):
 
         from omero.gateway import THISPATH
         self.GATEWAYPATH = THISPATH
-        self.font_path = os.path.join(THISPATH, "pilfonts", "FreeSans.ttf")
 
         self.ns = "omero.web.figure.tiff"
         self.mimetype = "image/tiff"
@@ -1463,10 +1462,18 @@ class TiffExport(FigureExport):
         """ TIFF export doesn't add ROIs to page (does it to panel)"""
         pass
 
-    def get_font(self, fontsize):
+    def get_font(self, fontsize, bold=False, italics=False):
         """ Try to load font from known location in OMERO """
+        font_name = "FreeSans.ttf"
+        if bold and italics:
+            font_name = "FreeSansBoldOblique.ttf"
+        elif bold:
+            font_name = "FreeSansBold.ttf"
+        elif italics:
+            font_name = "FreeSansOblique.ttf"
+        path_to_font = os.path.join(self.GATEWAYPATH, "pilfonts", font_name)
         try:
-            font = ImageFont.truetype(self.font_path, fontsize)
+            font = ImageFont.truetype(path_to_font, fontsize)
         except:
             font = ImageFont.load(
                 '%s/pilfonts/B%0.2d.pil' % (self.GATEWAYPATH, 24))
@@ -1550,35 +1557,106 @@ class TiffExport(FigureExport):
             y += 1
             y2 += 1
 
+    def draw_temp_label(self, text, fontsize, rgb):
+        """Returns a new PIL image with text. Handles html."""
+        tokens = self.parse_html(text)
+
+        widths = []
+        heights = []
+        for t in tokens:
+            font = self.get_font(fontsize, t['bold'], t['italics'])
+            txt_w, txt_h = font.getsize(t['text'])
+            widths.append(txt_w)
+            heights.append(txt_h)
+        
+        label_w = sum(widths)
+        label_h = max(heights)
+
+        temp_label = Image.new('RGBA', (label_w, label_h), (255, 255, 255, 0))
+        textdraw = ImageDraw.Draw(temp_label)
+
+        w = 0
+        for t in tokens:
+            font = self.get_font(fontsize, t['bold'], t['italics'])
+            txt_w, txt_h = font.getsize(t['text'])
+            textdraw.text((w, 0), t['text'], font=font, fill=rgb)
+            w += txt_w
+        return temp_label
+
+    def parse_html(self, html):
+        """
+        Parse html to give list of tokens with bold or italics
+
+        Returns list of [{'text': txt, 'bold': true, 'italics': false}]
+        """
+        in_bold = False
+        in_italics = False
+
+        # Remove any <p> tags
+        html = html.replace('<p>', '')
+        html = html.replace('</p>', '')
+
+        tokens = []
+        token = ""
+        i = 0
+        while i < len(html):
+            new_bold = False
+            new_italics = False
+            # look for start / end of b or i elements
+            start_bold = html[i:].startswith("<strong>")
+            end_bold = html[i:].startswith("</strong>")
+            start_ital = html[i:].startswith("<em>")
+            end_ital = html[i:].startswith("</em>")
+
+            if start_bold:
+                i += len("<strong>")
+            elif end_bold:
+                i += len("</strong>")
+            elif start_ital:
+                i += len("<em>")
+            elif end_ital:
+                i += len("</em>")
+
+            # if style has changed:
+            if start_bold or end_bold or start_ital or end_ital:
+                # save token with previous style
+                tokens.append({'text': token, 'bold': in_bold, 'italics': in_italics})
+                token = ""
+                if start_bold or end_bold:
+                    in_bold = start_bold
+                elif start_ital or end_ital:
+                    in_italics = start_ital
+            else:
+                token = token + html[i]
+                i += 1
+        tokens.append({'text': token, 'bold': in_bold, 'italics': in_italics})
+        return tokens
+
     def draw_text(self, text, x, y, fontsize, rgb, align="center"):
         """ Add text to the current figure page """
         x = self.scale_coords(x)
+        y = y - 5       # seems to help, but would be nice to fix this!
+        y = self.scale_coords(y)
         fontsize = self.scale_coords(fontsize)
 
-        font = self.get_font(fontsize)
-        txt_w, txt_h = font.getsize(text)
+        if markdown_imported:
+            # convert markdown to html
+            text = markdown.markdown(text)
+
+        temp_label = self.draw_temp_label(text, fontsize, rgb)
+
 
         if align == "vertical":
-            # write text on temp image (transparent)
-            y = self.scale_coords(y)
-            x = int(round(x))
-            y = int(round(y))
-            temp_label = Image.new('RGBA', (txt_w, txt_h), (255, 255, 255, 0))
-            textdraw = ImageDraw.Draw(temp_label)
-            textdraw.text((0, 0), text, font=font, fill=rgb)
-            w = temp_label.rotate(90, expand=True)
-            # Use label as mask, so transparent part is not pasted
-            y = y - (w.size[1]/2)
-            self.tiff_figure.paste(w, (x, y), mask=w)
-        else:
-            y = y - 5       # seems to help, but would be nice to fix this!
-            y = self.scale_coords(y)
-            textdraw = ImageDraw.Draw(self.tiff_figure)
-            if align == "center":
-                x = x - (txt_w / 2)
-            elif align == "right":
-                x = x - txt_w
-            textdraw.text((x, y), text, font=font, fill=rgb)
+            temp_label = temp_label.rotate(90, expand=True)
+            y = y - (temp_label.size[1]/2)
+        elif align == "center":
+            x = x - (temp_label.size[0] / 2)
+        elif align == "right":
+                x = x - temp_label.size[0]
+        x = int(round(x))
+        y = int(round(y))
+        # Use label as mask, so transparent part is not pasted
+        self.tiff_figure.paste(temp_label, (x, y), mask=temp_label)
 
     def save_page(self):
         """

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -146,8 +146,8 @@
                 if (typeof ljson.text == 'undefined' && ljson.time) {
                     ljson.text = self.model.get_time_label_text(ljson.time);
                 } else {
-                    // Escape all labels so they are safe
-                    ljson.text = _.escape(ljson.text);
+                    // Markdown also escapes all labels so they are safe
+                    ljson.text = markdown.toHTML(ljson.text);
                 }
                 positions[l.position].push(ljson);
             });


### PR DESCRIPTION
**Not ready to test/merge until after 3.0.0 release.**

Adds support for markdown bold and italics for figure labels.
See https://trello.com/c/BNjiEiAZ/46-labels-italics

Labels are formatted in the figure app (markdown in js), and also in figure export (converted to html using python markdown and then applied to PDF with reportlab or to TIFF with PIL using appropriate fonts (requires https://github.com/openmicroscopy/openmicroscopy/pull/5237 for new fonts).
