### PR TITLE
pretty print figure json

### DIFF
--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -200,6 +200,9 @@ def save_web_figure(request, conn=None, **kwargs):
             first_img_id = long(image_ids[0])
         # remove duplicates
         image_ids = list(set(image_ids))
+        # pretty-print json
+        figure_json = json.dumps(json_data, sort_keys=True,
+                                 indent=2, separators=(',', ': '))
     except:
         pass
 


### PR DESCRIPTION
This PR pretty-prints the json when saving a figure file, so that the
json in the file is human readable and more amenable to version control (since it's not all on one line).

See https://trello.com/c/sQw7eU4K/15-pretty-print-json-when-saving-to-file

To test:
    - Save a figure file and note the file-annotation ID (in figure URL)
    - Get the original file ID: ``` select file from annotation where id=32052```
    - Check that the file is nicely formatted - Can download the file after manually attaching the figure file to an Image in the clients OR find the original file ID and go to /webclient/get_original_file/{id}/
    - Refresh the figure page to check that the file still loads correctly.