### PR TITLE
slider range fix

### DIFF
--- a/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
+++ b/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
@@ -1533,7 +1533,7 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
                           'cursor': 'default'});
     this.selectRegion = this.paper.rect(0, 0, width, height);
     this.selectRegion.hide().attr({'stroke': '#ddd',
-                                   'stroke-width': 1,
+                                   'stroke-width': 0,
                                    'stroke-dasharray': '- '});
     if (this.canEdit) {
         this.newShapeBg.drag(

--- a/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
+++ b/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
@@ -1530,6 +1530,7 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
     this.newShapeBg = this.paper.rect(0, 0, width, height);
     this.newShapeBg.attr({'fill':'#000',
                           'fill-opacity':0.01,
+                          'stroke-width': 0,
                           'cursor': 'default'});
     this.selectRegion = this.paper.rect(0, 0, width, height);
     this.selectRegion.hide().attr({'stroke': '#ddd',

--- a/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
+++ b/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
@@ -1530,7 +1530,6 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
     this.newShapeBg = this.paper.rect(0, 0, width, height);
     this.newShapeBg.attr({'fill':'#000',
                           'fill-opacity':0.01,
-                          'stroke-width': 0,
                           'cursor': 'default'});
     this.selectRegion = this.paper.rect(0, 0, width, height);
     this.selectRegion.hide().attr({'stroke': '#ddd',

--- a/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
+++ b/omero_figure/static/figure/3rdparty/shape-editor-2.0.0/shape-editor.js
@@ -1534,7 +1534,7 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
                           'cursor': 'default'});
     this.selectRegion = this.paper.rect(0, 0, width, height);
     this.selectRegion.hide().attr({'stroke': '#ddd',
-                                   'stroke-width': 0,
+                                   'stroke-width': 1,
                                    'stroke-dasharray': '- '});
     if (this.canEdit) {
         this.newShapeBg.drag(

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -104,8 +104,9 @@ var ChannelSliderView = Backbone.View.extend({
                 var endAvg = parseInt(ends.reduce(addFn, 0) / ends.length, 10);
                 var startsNotEqual = starts.reduce(allEqualFn, starts[0]) === false;
                 var endsNotEqual = ends.reduce(allEqualFn, ends[0]) === false;
-                var min = mins.reduce(reduceFn(Math.min), 9999);
-                var max = maxs.reduce(reduceFn(Math.max), -9999);
+                var min = mins.reduce(reduceFn(Math.min));
+                var max = maxs.reduce(reduceFn(Math.max));
+                console.log(min, max);
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
                 var lutBgPos = FigureLutPicker.getLutBackgroundPosition(color);
                 if (color == "FFFFFF") color = "ccc";  // white slider would be invisible

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -106,7 +106,6 @@ var ChannelSliderView = Backbone.View.extend({
                 var endsNotEqual = ends.reduce(allEqualFn, ends[0]) === false;
                 var min = mins.reduce(reduceFn(Math.min));
                 var max = maxs.reduce(reduceFn(Math.max));
-                console.log(min, max);
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
                 var lutBgPos = FigureLutPicker.getLutBackgroundPosition(color);
                 if (color.toUpperCase() === "FFFFFF") color = "ccc";  // white slider would be invisible

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -109,7 +109,7 @@ var ChannelSliderView = Backbone.View.extend({
                 console.log(min, max);
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
                 var lutBgPos = FigureLutPicker.getLutBackgroundPosition(color);
-                if (color == "FFFFFF") color = "ccc";  // white slider would be invisible
+                if (color.toUpperCase() === "FFFFFF") color = "ccc";  // white slider would be invisible
 
                 // Make sure slider range is increased if needed to include current values
                 min = Math.min(min, startAvg);


### PR DESCRIPTION
As noticed by @bramalingam, if images have min-intensity above 9999 then the slider range ```min``` was incorrectly set at 9999, since this was hard coded.
Same is true for slider max.
This should now be fixed.

To test:
 - For image where min pixel intensity of a channel > 9999, channel slider min should be set correctly.
 - Same is true for images where max < -9999, but it might be tricky to find such an image, so I think we can assume that if the fix works for min, it also works for max.
