### PR TITLE
basic working flip behaviour

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -18,6 +18,7 @@
             selected: false,
             pixel_size_x_symbol: '\xB5m',     // microns by default
             pixel_size_x_unit: 'MICROMETER',
+            flip: true,
 
             // 'export_dpi' optional value to resample panel on export
             // model includes 'scalebar' object, e.g:
@@ -604,14 +605,16 @@
                 }
             }
 
+            var flip = this.get('flip') ? -1 : 1;
+            console.log('flip', flip, this.get('flip'));
             var css = {'left':img_x,
                        'top':img_y,
                        'width':img_w,
                        'height':img_h,
                        '-webkit-transform-origin': transform_x + '% ' + transform_y + '%',
                        'transform-origin': transform_x + '% ' + transform_y + '%',
-                       '-webkit-transform': 'rotate(' + rotation + 'deg)',
-                       'transform': 'rotate(' + rotation + 'deg)'
+                       '-webkit-transform': 'rotate(' + rotation + 'deg) scaleX(' + flip + ')',
+                       'transform': 'rotate(' + rotation + 'deg) scaleX(' + flip + ')'
                    };
             return css;
         },

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -15,7 +15,7 @@
             // we render on Changes in the model OR selected shape etc.
             this.model.on('destroy', this.remove, this);
             this.listenTo(this.model,
-                'change:x change:y change:width change:height change:zoom change:dx change:dy change:rotation',
+                'change:x change:y change:width change:height change:zoom change:dx change:dy change:rotation change:flip',
                 this.render_layout);
             this.listenTo(this.model, 'change:scalebar change:pixel_size_x', this.render_scalebar);
             this.listenTo(this.model,

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1511,6 +1511,18 @@
             "click .dropdown-menu a": "pick_color",
             "click .show-rotation": "show_rotation",
             "click .z-projection": "z_projection",
+            "click .flip": "flip_panel",
+        },
+
+        flip_panel: function(event) {
+
+            var flip = event.target.checked;
+            console.log("flip!!!", flip);
+
+            this.models.forEach(function(m){
+
+                m.set('flip', flip);
+            });
         },
 
         z_projection:function(e) {
@@ -1705,9 +1717,16 @@
                     ch.lutBgPos = FigureLutPicker.getLutBackgroundPosition(ch.color);
                     return ch;
                 });
+
+                var flipped = this.models.reduce(function(prev, m) {
+                    return prev && m.get('flip');
+                }, true);
+                console.log('flipped', flipped);
+
                 html = this.template({'channels':json,
                     'z_projection_disabled': z_projection_disabled,
                     'rotation': rotation,
+                    'flipped': flipped,
                     'z_projection': z_projection});
                 this.$el.html(html);
             }

--- a/src/templates/channel_toggle_template.html
+++ b/src/templates/channel_toggle_template.html
@@ -63,3 +63,11 @@ class="btn btn-default channel-btn lutBg"
             <span class="glyphicon"></span>
         </button>
     </div>
+
+    <div>
+        <input type="checkbox" class="flip"
+            <% if(flipped) { %>checked<% } %>
+        ></input>
+    </div>
+
+


### PR DESCRIPTION
See https://trello.com/c/wlX18bfE/128-flip-vertical-or-horizontal

Work in progress.

cc @carandraug

TODO:

 - [ ] Handle drag/pan in right view-port with  ```right_panel_view.js``` ```correct_rotation(dx, dy, rotation)```
 - [ ] Maybe ```flip``` variable on PanelModel should be ```flip_x``` in case we decide in this PR or later that we also need a ```flip_y``` option too?
 - [ ] We probably need to move the Channel toggle buttons down, alongside the channel sliders, in order to make more space for a Flip button (should be a different PR). Flip button could be a single toggle button (like the Z-projection button) or if we want flip horizontal and vertical then a button might have a drop-down with checkbox menu for Vertical and Horizontal.
 - [ ] In the ROI dialog, we need to cancel the flip (same as we do with rotation) so that drawing isn't broken with the same drag issues we see in the viewport.
 - [ ] Export script needs to handle flipped images for PDF and TIFF export