### PR TITLE
reverseIntensity keyError export

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -759,7 +759,7 @@ class FigureExport(object):
                 c_idxs.append(i+1)
                 windows.append([c['window']['start'], c['window']['end']])
                 colors.append(c['color'])
-                reverses.append(c['reverseIntensity'])
+                reverses.append(c.get('reverseIntensity', False))
 
         image.setActiveChannels(c_idxs, windows, colors, reverses)
 


### PR DESCRIPTION
Fixes bug with export of images that were added to figures before 'reverseIntensity' was supported (before 5.3.0).
Reported to @kennethgillen from nightshade:
https://trello.com/c/baovPrAJ/7-reverseintensity-keyerror-in-export

To test:
 - I reproduced the bug by manually removing 'reverseIntensity' info from the JSON:
     - File -> Export as JSON
     - Copy this data, removing the ```, "reverseIntensity": true``` (only need to do this for a single active channel of a single image.
     - Create a new figure with this text via File -> Import from JSON.
 - Export of this figure should not cause any error.

cc @jburel - We should probably release this as a 3.1.1 bug-fix ASAP.