### PR TITLE
Labels from channel with lut fix

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -243,11 +243,13 @@
             var newLabels = [];
             _.each(this.get('channels'), function(c){
                 if (c.active) {
+                    // If channel has LUT, make grey (visible on black/white bg)
+                    var chColor = c.color.endsWith('lut') ? 'BBBBBB' : c.color;
                     newLabels.push({
                         'text': c.label,
                         'size': options.size,
                         'position': options.position,
-                        'color': options.color || c.color
+                        'color': options.color || chColor
                     });
                 }
             });

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -280,11 +280,7 @@ var RoiModalView = Backbone.View.extend({
             event.preventDefault();
             var $a = $(event.target),
                 $span = $a.children('span');
-            // For the Label Text, handle this differently...
-            if ($a.attr('data-label')) {
-                $('.new-label-form .label-text', this.$el).val( $a.attr('data-label') );
-            }
-            // All others, we take the <span> from the <a> and place it in the <button>
+            // Take the <span> from the <a> and place it in the <button>
             if ($span.length === 0) $span = $a;  // in case we clicked on <span>
             var $li = $span.parent().parent(),
                 $button = $li.parent().prev();


### PR DESCRIPTION
Fixes a bug that has been around since LUTs were supported in OMERO.figure:
See https://trello.com/c/jOCVW3Co/8-bug-create-labels-from-channels-with-luts

To test:
 - Set LUT on a channel
 - Create labels from channels
 - Labels from LUT channels should be grey
 - Export should work as normal