### PR TITLE
Remove unused function arguments and conversion between radians and degrees

### DIFF
--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1121,13 +1121,12 @@
                 return {'dx': dx, 'dy': dy};
             }
             var length = Math.sqrt(dx * dx + dy * dy),
-                ang1 = Math.atan(dy/dx),
-                deg1 = ang1/(Math.PI/180);  // rad -> deg
+                ang1 = Math.atan(dy/dx);
             if (dx < 0) {
-                deg1 = 180 + deg1;
+                ang1 = Math.PI + ang1;
             }
-            var deg2 = deg1 - this.r,
-                ang2 = deg2 * (Math.PI/180);  // deg -> rad
+            var angr = this.r * (Math.PI/180),  // deg -> rad
+                ang2 = ang1 - angr;
             dx = Math.cos(ang2) * length;
             dy = Math.sin(ang2) * length;
             return {'dx': dx, 'dy': dy};

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1092,7 +1092,7 @@
             var dx = event.clientX - this.dragstart_x,
                 dy = event.clientY - this.dragstart_y;
             if (this.r !== 0) {
-                var xy = this.correct_rotation(dx, dy, this.r);
+                var xy = this.correct_rotation(dx, dy);
                 dx = xy.dx;
                 dy = xy.dy;
             }
@@ -1106,7 +1106,7 @@
                 var dx = event.clientX - this.dragstart_x,
                     dy = event.clientY - this.dragstart_y;
                 if (this.r !== 0) {
-                    var xy = this.correct_rotation(dx, dy, this.r);
+                    var xy = this.correct_rotation(dx, dy);
                     dx = xy.dx;
                     dy = xy.dy;
                 }
@@ -1116,7 +1116,7 @@
         },
 
         // if the panel is rotated by css, drag events need to be corrected
-        correct_rotation: function(dx, dy, rotation) {
+        correct_rotation: function(dx, dy) {
             if (dx === 0 && dy === 0) {
                 return {'dx': dx, 'dy': dy};
             }


### PR DESCRIPTION
While checking how the rotation is done to add a button for horizontal flip, I noticed this unused arguments and extra computations.