### PR TITLE
Reverse intensity rename Figure

### DIFF
--- a/src/templates/channel_slider_template.html
+++ b/src/templates/channel_slider_template.html
@@ -20,7 +20,7 @@ class="btn btn-default channel-btn lutBg"
                         <span style="font-size: 18px; position: relative; top: 4px;;"
                             class="glyphicon
                             <% if(reverse) { %>glyphicon-check<% } else { %>glyphicon-unchecked<% } %>">
-                        </span> Reverse Intensity
+                        </span> Invert
                     </a>
                 </li>
                 <li class="divider"></li>


### PR DESCRIPTION
Simply changes the 'Reverse Intensity' label to 'Invert', to be consistent with the other clients.