### PR TITLE
IE11_fix

### DIFF
--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -39,6 +39,21 @@ JSON.stringify = JSON.stringify || function (obj) {
 };
 
 
+// Polyfill for IE
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if (!String.prototype.endsWith)
+  String.prototype.endsWith = function(searchStr, Position) {
+      // This works much better than >= because
+      // it compensates for NaN:
+      if (!(Position < this.length))
+        Position = this.length;
+      else
+        Position |= 0; // round position
+      return this.substr(Position - searchStr.length,
+                         searchStr.length) === searchStr;
+  };
+
+
 var figureConfirmDialog = function(title, message, buttons, callback) {
     var $confirmModal = $("#confirmModal"),
         $title = $(".modal-title", $confirmModal),


### PR DESCRIPTION
This fixes showing channel buttons in IE.
https://trello.com/c/opKitwD9/12-ie-11-support

To test, confirm that figures display correctly in IE11.
You can easily download IE11 on Windows7 VM for virtualBox from https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/
Download, unzip then double-click on the ```IE11 - Win7.ovf``` to open in virtualBox.