### PR TITLE
list files user middlename

### DIFF
--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -112,7 +112,8 @@ def index(request, file_id=None, conn=None, **kwargs):
     script_service = conn.getScriptService()
     sid = script_service.getScriptID(SCRIPT_PATH)
     script_missing = sid <= 0
-    user_full_name = conn.getUser().getFullName()
+    user = conn.getUser()
+    user_full_name = "%s %s" % (user.firstName, user.lastName)
 
     context = {'scriptMissing': script_missing,
                'userFullName': user_full_name,


### PR DESCRIPTION
Fixes a minor bug where if a user has a middle-name set, they won't see any files listed when they first open the Files > Open dialog in figure.
Noticed for user-4 in web-dev-merge.

To test:
 - Set a middle-name in user settings (or use user-4 in web-dev-merge) and in figure, Open Files dialog should show your own files when first opened.