### PR TITLE
Crop page to panels

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -53,7 +53,6 @@ except ImportError:
 try:
     from reportlab.pdfgen import canvas
     from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-    from reportlab.lib.units import inch
     from reportlab.platypus import Paragraph
     from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT
     reportlab_installed = True
@@ -1176,8 +1175,9 @@ class FigureExport(object):
         """ Adds paragraph text to point on PDF info page """
 
         c = self.figure_canvas
-        aw = self.page_width - (inch * 2)
-        maxh = self.page_height - inch
+        margin = self.margin
+        aw = self.page_width - (margin * 2)
+        maxh = self.page_height - margin
         spacer = 10
         imgw = imgh = 25
         # Some html from markdown may not be compatible
@@ -1194,14 +1194,13 @@ class FigureExport(object):
         else:
             parah = h
         # If there's not enough space, start a new page
-        if parah > (page_y - inch):
+        if parah > (page_y - margin):
             c.save()
             page_y = maxh    # reset to top of new page
-        indent = inch
         if thumb_src is not None:
-            c.drawImage(thumb_src, inch, page_y - imgh, imgw, imgh)
-            indent = indent + imgw + spacer
-        para.drawOn(c, indent, page_y - h)
+            c.drawImage(thumb_src, margin, page_y - imgh, imgw, imgh)
+            margin = margin + imgw + spacer
+        para.drawOn(c, margin, page_y - h)
         return page_y - parah - spacer  # reduce the available height
 
     def add_read_me_file(self):
@@ -1229,10 +1228,10 @@ class FigureExport(object):
         style_h3 = styles['Heading3']
 
         scalebars = []
-        maxh = page_height - inch
+        self.margin = min(self.page_width, self.page_height) / 9.0
 
         # Start adding at the top, update page_y as we add paragraphs
-        page_y = maxh
+        page_y = page_height - self.margin
         page_y = self.add_para_with_thumb(figure_name, page_y, style=style_h)
 
         if "Figure_URI" in script_params:
@@ -1528,8 +1527,8 @@ class TiffExport(FigureExport):
         Creates a new PIL image ready to receive panels, labels etc.
         This is created for each page in the figure.
         """
-        tiff_width = self.scale_coords(self.page_width)
-        tiff_height = self.scale_coords(self.page_height)
+        tiff_width = int(self.scale_coords(self.page_width))
+        tiff_height = int(self.scale_coords(self.page_height))
         rgb = (255, 255, 255)
         page_color = self.figure_json.get('page_color')
         if page_color is not None:

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -677,8 +677,9 @@
             this.notifySelectionChange();
         },
 
-        cropPageToPanels: function() {
-            // we need to resize page AND re-position panels to top-left
+        getCropCoordinates: function() {
+            // Get paper size and panel offsets (move to top-left) for cropping
+            // returns {'paper_width', 'paper_height', 'dx', 'dy'}
             var margin = 10;
 
             // get range of all panel coordinates
@@ -694,14 +695,13 @@
             // Shift panels to top-left corner
             var dx = margin - left;
             var dy = margin - top;
-            this.panels.forEach(function(p){
-                p.save({'x': p.get('x') + dx,
-                        'y': p.get('y') + dy});
-            });
 
-            // Resize paper
-            this.set({'paper_width': right - left + (2 * margin),
-                      'paper_height': bottom - top + (2 * margin)});
+            return {
+                    'paper_width': right - left + (2 * margin),
+                    'paper_height': bottom - top + (2 * margin),
+                    'dx': dx,
+                    'dy': dy
+                   };
         },
 
         notifySelectionChange: function() {

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -677,6 +677,31 @@
             this.notifySelectionChange();
         },
 
+        cropPageToPanels: function() {
+            // we need to resize page AND re-position panels to top-left
+            var margin = 10;
+
+            // get range of all panel coordinates
+            var left = this.panels.getMin('x');
+            var top = this.panels.getMin('y');
+            var right = Math.max.apply(window, this.panels.map(
+                function(m){return m.get('x') + m.get('width')}));
+            var bottom = Math.max.apply(window, this.panels.map(
+                function(m){return m.get('y') + m.get('height')}));
+
+            // Shift panels to top-left corner
+            var dx = margin - left;
+            var dy = margin - top;
+            this.panels.forEach(function(p){
+                p.save({'x': p.get('x') + dx,
+                        'y': p.get('y') + dy});
+            });
+
+            // Resize paper
+            this.set({'paper_width': right - left + (2 * margin),
+                      'paper_height': bottom - top + (2 * margin)});
+        },
+
         notifySelectionChange: function() {
             this.trigger('change:selection');
         }

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -682,12 +682,14 @@
             var margin = 10;
 
             // get range of all panel coordinates
-            var left = this.panels.getMin('x');
-            var top = this.panels.getMin('y');
+            var top = Math.min.apply(window, this.panels.map(
+                function(p){return p.getBoundingBoxTop();}));
+            var left = Math.min.apply(window, this.panels.map(
+                function(p){return p.getBoundingBoxLeft();}));
             var right = Math.max.apply(window, this.panels.map(
-                function(m){return m.get('x') + m.get('width')}));
+                function(p){return p.getBoundingBoxRight()}));
             var bottom = Math.max.apply(window, this.panels.map(
-                function(m){return m.get('y') + m.get('height')}));
+                function(p){return p.getBoundingBoxBottom()}));
 
             // Shift panels to top-left corner
             var dx = margin - left;

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -67,6 +67,8 @@
                     'canEdit': data.canEdit,
                     'paper_width': data.paper_width,
                     'paper_height': data.paper_height,
+                    'width_mm': data.width_mm,
+                    'height_mm': data.height_mm,
                     'page_size': data.page_size || 'letter',
                     'page_count': data.page_count,
                     'paper_spacing': data.paper_spacing,

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -661,28 +661,28 @@
         },
 
         getAverageWH: function() {
-            var sumWH = this.inject(function(memo, m){
+            var sumWH = this.reduce(function(memo, m){
                 return memo + (m.get('width')/ m.get('height'));
             }, 0);
             return sumWH / this.length;
         },
 
         getSum: function(attr) {
-            return this.inject(function(memo, m){
+            return this.reduce(function(memo, m){
                 return memo + (m.get(attr) || 0);
             }, 0);
         },
 
         getMax: function(attr) {
-            return this.inject(function(memo, m){ return Math.max(memo, m.get(attr)); }, 0);
+            return this.reduce(function(memo, m){ return Math.max(memo, m.get(attr)); }, 0);
         },
 
         getMin: function(attr) {
-            return this.inject(function(memo, m){ return Math.min(memo, m.get(attr)); }, Infinity);
+            return this.reduce(function(memo, m){ return Math.min(memo, m.get(attr)); }, Infinity);
         },
 
         allTrue: function(attr) {
-            return this.inject(function(memo, m){
+            return this.reduce(function(memo, m){
                 return (memo && m.get(attr));
             }, true);
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -631,11 +631,6 @@
             return dpi.toFixed(0);
         },
 
-        getBoundingBox: function() {
-            // Return {x, y, width, height} taking into account labels!
-
-        },
-
         getBoundingBoxTop: function() {
             // get top of panel including 'top' labels
             var labels = this.get("labels");

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -1,4 +1,7 @@
 
+    // Corresponds to css - allows us to calculate size of labels
+    var LINE_HEIGHT = 1.43;
+
     // ------------------------ Panel -----------------------------------------
     // Simple place-holder for each Panel. Will have E.g. imageId, rendering options etc
     // Attributes can be added as we need them.
@@ -626,6 +629,56 @@
                 scaling = orig_width / img_width,
                 dpi = scaling * 72;
             return dpi.toFixed(0);
+        },
+
+        getBoundingBox: function() {
+            // Return {x, y, width, height} taking into account labels!
+
+        },
+
+        getBoundingBoxTop: function() {
+            // get top of panel including 'top' labels
+            var labels = this.get("labels");
+            var y = this.get('y');
+            // get labels by position
+            var top_labels = labels.filter(function(l) {return l.position === 'top'});
+            // offset by font-size of each
+            y = top_labels.reduce(function(prev, l){
+                return prev - (LINE_HEIGHT * l.size);
+            }, y);
+            return y;
+        },
+
+        getBoundingBoxLeft: function() {
+            // get left of panel including 'leftvert' labels (ignore
+            // left horizontal labels - hard to calculate width)
+            var labels = this.get("labels");
+            var x = this.get('x');
+            // get labels by position
+            var left_labels = labels.filter(function(l) {return l.position === 'leftvert'});
+            // offset by font-size of each
+            x = left_labels.reduce(function(prev, l){
+                return prev - (LINE_HEIGHT * l.size);
+            }, x);
+            return x;
+        },
+
+        getBoundingBoxRight: function() {
+            // Ignore right (horizontal) labels since we don't know how long they are
+            return this.get('x') + this.get('width');
+        },
+
+        getBoundingBoxBottom: function() {
+            // get bottom of panel including 'bottom' labels
+            var labels = this.get("labels");
+            var y = this.get('y') + this.get('height');
+            // get labels by position
+            var bottom_labels = labels.filter(function(l) {return l.position === 'bottom'});
+            // offset by font-size of each
+            y = bottom_labels.reduce(function(prev, l){
+                return prev + (LINE_HEIGHT * l.size);
+            }, y);
+            return y;
         },
 
         // True if coords (x,y,width, height) overlap with panel

--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -116,6 +116,8 @@
                 h_pixels = coords.paper_height;
                 dx = coords.dx;
                 dy = coords.dy;
+                // Single page is cropped to include ALL panels
+                pageCount = 1;
             }
             if (w_mm && h_mm) {
                 // convert mm -> pixels (inch is 25.4 mm)

--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -160,7 +160,6 @@
             event.preventDefault();
             var json = this.processForm();
 
-            console.log(json);
             // if 'crop' page to panels
             if (json.page_size === 'crop') {
                 this.model.panels.forEach(function(p){

--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -149,7 +149,7 @@
                 'page_col_count': cols,
                 'page_color': pageColor,
             };
-            if (dx || dy) {
+            if (dx !== undefined || dy !== undefined) {
                 rv.dx = dx;
                 rv.dy = dy;
             }

--- a/src/templates/modal_dialogs/paper_setup_modal_template.html
+++ b/src/templates/modal_dialogs/paper_setup_modal_template.html
@@ -57,6 +57,9 @@
                     <option value="mm" <% if (page_size == 'mm') { print('selected') } %> >
                         Custom (mm)
                     </option>
+                    <option value="crop" <% if (page_size == 'crop') { print('selected') } %> >
+                        Crop page around panels
+                    </option>
                 </select>
             </div>
             <!-- <label for="inputPassword" class="col-sm-2 control-label">Password</label> -->

--- a/src/templates/modal_dialogs/paper_setup_modal_template.html
+++ b/src/templates/modal_dialogs/paper_setup_modal_template.html
@@ -57,8 +57,13 @@
                     <option value="mm" <% if (page_size == 'mm') { print('selected') } %> >
                         Custom (mm)
                     </option>
-                    <option value="crop" <% if (page_size == 'crop') { print('selected') } %> >
-                        Crop page around panels
+                    <option value="crop" <% if (page_size == 'crop') { print('selected') } %>
+                        title="Fit a single page around all panels">
+                        <% if (page_count > 1) { %>
+                            Crop single page to panels
+                        <% } else { %>
+                            Crop page around panels
+                        <% } %>
                     </option>
                 </select>
             </div>


### PR DESCRIPTION
This allows users to crop a figure to fit around panels.
See https://trello.com/c/lx5YoDTH/14-crop-page-to-panels

To test:
 - With several panels on a figure...
 - Choose File -> Paper setup and pick "Crop page around panels" from the Size options.
 - When OK is clicked, the page should be cropped around the panels, with a small margin.
 - This is added to the Undo queue and can be undone/redone in one action.
 - Subsequent editing of page Size should show that we now have a "Custom" size, and can tweak custom size further.