### PR TITLE
Add labels from tags

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -708,5 +708,38 @@
             }
         },
 
+        createLabelsFromTags(options) {
+            // Loads Tags for selected images and creates labels
+            var image_ids = this.map(function(s){return s.get('imageId')})
+            image_ids = "image=" + image_ids.join("&image=");
+            // TODO: Use /api/ when annotations is supported
+            var url = WEBINDEX_URL + "api/annotations/?type=tag&limit=1000&" + image_ids;
+            $.getJSON(url, function(data){
+                // Map {iid: {id: 'tag'}, {id: 'names'}}
+                var imageTags = data.annotations.reduce(function(prev, t){
+                    var iid = t.link.parent.id;
+                    if (!prev[iid]) {
+                        prev[iid] = {};
+                    }
+                    prev[iid][t.id] = t.textValue;
+                    return prev;
+                }, {});
+                // Apply tags to panels
+                this.forEach(function(p){
+                    var iid = p.get('imageId');
+                    var labels = _.values(imageTags[iid]).map(function(text){
+                        return {
+                            'text': text,
+                            'size': options.size,
+                            'position': options.position,
+                            'color': options.color
+                        }
+                    });
+
+                    p.add_labels(labels);
+                });
+            }.bind(this));
+        }
+
         // localStorage: new Backbone.LocalStorage("figureShop-backbone")
     });

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -327,6 +327,16 @@
                 return false;
             }
 
+            if (label_text == '[tags]') {
+                // Load Tags for this image and create labels
+
+                selected.createLabelsFromTags({
+                            position:position,
+                            size:font_size,
+                            color: color});
+                return false;
+            }
+
             var label = {
                 text: label_text,
                 size: parseInt(font_size, 10),

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -13,7 +13,12 @@
                     <li role="presentation" class="divider"></li>
                     <li><a href="#" data-label="[image-name]">Image Name</a></li>
                     <li><a href="#" data-label="[dataset-name]">Dataset Name</a></li>
-                    <li><a href="#" data-label="[channels]">Channels</a></li>
+                    <li title="Create labels from active Channels on the selected panel">
+                        <a href="#" data-label="[channels]">Channels</a>
+                    </li>
+                    <li title="Create labels from Tags on this Image in OMERO">
+                        <a href="#" data-label="[tags]">Tags</a>
+                    </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-secs]">Time (secs)</a>
                     </li>


### PR DESCRIPTION
Quick PR on the train to SMG 2017....

See https://trello.com/c/ZdmnimZj/64-labels-from-tags

This simply adds a label for every Tag on selected images.

To test:
 - When adding labels, choose ```[tags]``` option.
 - Tags added for each label (only 1 label even if multiple users have added the same Tag).