### PR TITLE
export_bug_dx_None

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -61,6 +61,7 @@ except ImportError:
     reportlab_installed = False
     logger.error("Reportlab not installed.")
 
+DEFAULT_OFFSET = 0
 
 ORIGINAL_DIR = "1_originals"
 RESAMPLED_DIR = "2_pre_resampled"
@@ -774,8 +775,8 @@ class FigureExport(object):
         zoom = float(panel['zoom'])
         frame_w = panel['width']
         frame_h = panel['height']
-        dx = panel.get('dx', 0)
-        dy = panel.get('dy', 0)
+        dx = panel.get('dx', DEFAULT_OFFSET)
+        dy = panel.get('dy', DEFAULT_OFFSET)
         orig_w = panel['orig_width']
         orig_h = panel['orig_height']
 
@@ -1065,8 +1066,8 @@ class FigureExport(object):
         size_y = image.getSizeY()
         cx = size_x/2
         cy = size_y/2
-        dx = panel.get('dx', 0)
-        dy = panel.get('dy', 0)
+        dx = panel.get('dx', DEFAULT_OFFSET)
+        dy = panel.get('dy', DEFAULT_OFFSET)
 
         cx += dx
         cy += dy

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -774,8 +774,8 @@ class FigureExport(object):
         zoom = float(panel['zoom'])
         frame_w = panel['width']
         frame_h = panel['height']
-        dx = panel['dx']
-        dy = panel['dy']
+        dx = panel.get('dx', 0)
+        dy = panel.get('dy', 0)
         orig_w = panel['orig_width']
         orig_h = panel['orig_height']
 
@@ -1065,8 +1065,8 @@ class FigureExport(object):
         size_y = image.getSizeY()
         cx = size_x/2
         cy = size_y/2
-        dx = panel['dx']
-        dy = panel['dy']
+        dx = panel.get('dx', 0)
+        dy = panel.get('dy', 0)
 
         cx += dx
         cy += dy


### PR DESCRIPTION
See https://trello.com/c/0TnhjDrs/1-export-bug-dx-none

This fixes a rarely seen bug (not sure how to reproduce it in normal use) in figure export.
Check that figure export still works as expected, with some images zoomed in and panned off-centre. Check cropped region is same in exported figure as in web.