### PR TITLE
fix theZ display in crop dialog

### DIFF
--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -384,14 +384,18 @@ var CropModalView = Backbone.View.extend({
                     cachedRois[roi.id] = shapes;
                     // get display shape for picking ROI
                     // on current plane or pick median T/Z...
-                    tkeys = _.keys(shapes).sort();
+                    tkeys = _.keys(shapes)
+                            .map(function(x){return parseInt(x, 10)})
+                            .sort(function(a, b){return a - b});    // sort numerically
                     if (tkeys.length === 0) continue;   // no Rectangles
                     if (shapes[currT]) {
                         t = currT;
                     } else {
                         t = tkeys[(tkeys.length/2)>>0]
                     }
-                    zkeys = _.keys(shapes[t]).sort();
+                    zkeys = _.keys(shapes[t])
+                            .map(function(x){return parseInt(x, 10)})
+                            .sort(function(a, b){return a - b});    // sort numerically
                     if (shapes[t][currZ]) {
                         z = currZ;
                     } else {


### PR DESCRIPTION
Fixes https://trello.com/c/imMLEy89/100-bug-figure-crop-dialog-thez-display

To test:

 - Add rectangles on a multi-Z image in Insight, so that the Z range goes from below 100 to over 100 OR from below 10 to above 10.

 - Add the image to a Figure and click on the Crop button to launch the dialog

 - Check that the Z-index ranges are the same as created in Insight.

Before and after shots below:

![screen shot 2018-01-11 at 16 15 47](https://user-images.githubusercontent.com/900055/34835153-e50420d4-f6eb-11e7-8bf9-5570773d9baa.png)
![screen shot 2018-01-11 at 16 16 12](https://user-images.githubusercontent.com/900055/34835158-e9cfbd4e-f6eb-11e7-8388-8166bb93e815.png)
