### PR TITLE
reportlab_3_4_bugfix

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1195,7 +1195,7 @@ class FigureExport(object):
             parah = h
         # If there's not enough space, start a new page
         if parah > (page_y - margin):
-            c.save()
+            c.showPage()
             page_y = maxh    # reset to top of new page
         if thumb_src is not None:
             c.drawImage(thumb_src, margin, page_y - imgh, imgw, imgh)


### PR DESCRIPTION
Fixes https://trello.com/c/KEIu1LhB/17-bug-reportlab-34-export

This fixes an error seen when exporting a figure with lots of images, so that the Info section is more than 1 page. Only seen with reportlab 3.4.0.

To test:
 - need to install reportlab 3.4.0
 - Add lots (e.g. 20) images to a figure and export PDF
 - Check that you can export 2 or more info pages
 - NB: Also good to check that this doesn't break using reportlab installed via ```yum install python-reportlab``` as on web-dev-merge.