### PR TITLE
Scripts parameters

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1838,13 +1838,14 @@ def run_script():
         scripts.String("Export_Option", values=export_options,
                        default="PDF"),
 
-        scripts.String("Webclient_URI", grouping="4",
+        scripts.String("Webclient_URI", optional=False, grouping="4",
                        description="webclient URL for adding links to images"),
 
         scripts.String("Figure_Name", grouping="4",
                        description="Name of the Pdf Figure"),
 
-        scripts.String("Figure_URI", description="URL to the Figure")
+        scripts.String("Figure_URI", optional=False,
+                       description="URL to the Figure")
     )
 
     try:


### PR DESCRIPTION
Parameters are not optional as indicated
This PR clearly sets the flag

Discovered while working on https://github.com/ome/omero-figure/pull/259
cc @will-moore 

This could be included in 3.2.0
we can then relax later on but at the moment it is broken