### PR TITLE
Remove optional

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1844,7 +1844,7 @@ def run_script():
         scripts.String("Figure_Name", grouping="4",
                        description="Name of the Pdf Figure"),
 
-        scripts.String("Figure_URI", optional=False,
+        scripts.String("Figure_URI",
                        description="URL to the Figure")
     )
 

--- a/test/integration/test_figure_scripts.py
+++ b/test/integration/test_figure_scripts.py
@@ -62,7 +62,6 @@ class TestFigureScripts(ScriptTest):
             "Figure_JSON": omero.rtypes.rstring(json),
             "Export_Option": omero.rtypes.rstring(export_option),
             "Figure_Name": omero.rtypes.rstring(figure_name),
-            "Figure_URI": omero.rtypes.rstring(uri),
             "Webclient_URI": omero.rtypes.rstring(uri)
         }
         ann = run_script(client, id, args, "New_Figure")


### PR DESCRIPTION
Fix an error when trying to export unsaved figures as PDF/TIFF

see https://trello.com/c/YkngbZ79/175-export-without-saving-figure

cc @will-moore 

To test:

 * Open an image in Figure. **DO NOT SAVE THE FIGURE**
 * Export the figure 