### PR TITLE
svg_resize_on_init

### DIFF
--- a/src/js/views/svg_model_view.js
+++ b/src/js/views/svg_model_view.js
@@ -391,6 +391,9 @@
                 rv = new RectView({'model':multiSelectRect, 'paper':this.raphael_paper,
                         'handle_wh':7, 'handles_toFront': true, 'fixed_ratio': true});
             rv.selected_line_attrs = {'stroke-width': 1, 'stroke':'#4b80f9'};
+
+            // set svg size for current window and zoom
+            this.renderZoom();
         },
 
         // A panel has been added - We add a corresponding Raphael Rect 


### PR DESCRIPTION
Fixes a small bug noticed on very large, high resolution monitors: https://trello.com/c/BnJ6wTz1/168-big-screens-svg-doesnt-resize-to-fit

To test:
 - Open figure on a large, high resolution monitor
 - Try drag-selection on the canvas (shows dotted selection outline) right down to the bottom-right corner. The drag outline should be able to extend fully down to the corner.