### PR TITLE
T-index label

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -872,9 +872,9 @@ class FigureExport(object):
 
     def get_time_label_text(self, delta_t, format):
         """ Gets the text for 'live' time-stamp labels """
-        if format == "secs":
-            text = "%s secs" % delta_t
-        elif format == "mins":
+        # format of "secs" by default
+        text = "%s secs" % delta_t
+        if format == "mins":
             text = "%s mins" % int(round(float(delta_t) / 60))
         elif format == "hrs:mins":
             h = (delta_t / 3600)
@@ -924,11 +924,13 @@ class FigureExport(object):
 
         for l in labels:
             if 'text' not in l:
-                if 'deltaT' in panel and panel['theT'] < len(panel['deltaT']):
-                    the_t = panel['theT']
+                the_t = panel['theT']
+                timestamps = panel.get('deltaT')
+                if l.get('time') == "index":
+                    l['text'] = str(the_t + 1)
+                elif timestamps and panel['theT'] < len(timestamps):
                     d_t = panel['deltaT'][the_t]
-                    text = self.get_time_label_text(d_t, l['time'])
-                    l['text'] = text
+                    l['text'] = self.get_time_label_text(d_t, l['time'])
                 else:
                     continue
 

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -276,7 +276,9 @@
             var theT = this.get('theT'),
                 deltaT = this.get('deltaT')[theT] || 0,
                 text = "", h, m, s;
-            if (format === "secs") {
+            if (format === "index") {
+                text = "" + (theT + 1);
+            } else if (format === "secs") {
                 text = deltaT + " secs";
             } else if (format === "mins") {
                 text = Math.round(deltaT / 60) + " mins";

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -19,6 +19,9 @@
                     <li title="Create labels from Tags on this Image in OMERO">
                         <a href="#" data-label="[tags]">Tags</a>
                     </li>
+                    <li title="Add a label that shows the current T-index">
+                        <a href="#" data-label="[time-index]">Time (index)</a>
+                    </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-secs]">Time (secs)</a>
                     </li>


### PR DESCRIPTION
See https://trello.com/c/cVYdrcXM/131-no-time-stamp-use-t-index-instead
Adds support for labels showing T-index.
Useful if the image doesn't have timestamp metadata.

To test:
 - Add Timelapse images to figure, with and without Time-stamp metadata.
 - Choose to create label from ```Time (index)``` option (NB: this option will not be disabled in image with no timestamp metadata)
 - Label should show the current T-index for the panel
 - Export of the figure should also show correct T-index label for both images.