### PR TITLE
save cancel fix

### DIFF
--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -411,7 +411,6 @@
                 event.preventDefault();
             }
             this.$saveBtn.tooltip('hide');
-            this.$saveBtn.attr('disabled', 'disabled');
             this.save_figure();
         },
 
@@ -421,6 +420,8 @@
             var fileId = this.model.get('fileId'),
                 canEdit = this.model.get('canEdit');
             if (fileId && canEdit) {
+                // Prevent double-click
+                this.$saveBtn.attr('disabled', 'disabled');
                 // Save
                 options.fileId = fileId;
                 this.model.save_to_OMERO(options);


### PR DESCRIPTION
From bug reported at https://docs.google.com/spreadsheets/d/1qdOAv0wUgAVHEtlVroOwkeNUoNwst-APSPFJk6-3Sz8/edit#gid=0

* Click New
* Add image ID 
* File -> Save. Use short-cut. 
* Do not Save. Click cancel
* Save button in the header is not longer active. 
* Cannot save from header any more
* Note that the button does not become active after actions e.g. rotate image

To test, repeat above but the Save button does not become disabled if we Cancel the save.
If save goes ahead, the Save button is disabled in the normal way.

The immediate disabling of the Save button when it's clicked was added to prevent Double-click performing a 2 Save POSTs when saving a pre-saved figure (no "Figure Name" prompt). Now we handle that elsewhere (not in the Save-As path).