### PR TITLE
Layout and help url fixes

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -100,7 +100,7 @@
                 <div class="modal-body" style="padding: 25px 25px 35px 25px; text-align:center">
                     <p><strong>Version</strong>: <script>document.write(RELEASE_VERSION)</script></p>
                     <p>For more information, visit the
-                        <a target="new" href="http://figure.openmicroscopy.org">OMERO.figure Home Page</a>
+                        <a target="new" href="https://www.openmicroscopy.org/omero/figure/">OMERO.figure Home Page</a>
                     </p>
                     <p>
                         &copy; 2013-{% now "Y" %} University of Dundee &amp; Open Microscopy Environment<br/>
@@ -645,7 +645,7 @@
                                 <a href="#">About OMERO.figure</a>
                             </li>
                             <li>
-                                <a href="http://figure.openmicroscopy.org" target="new">
+                                <a href="https://www.openmicroscopy.org/omero/figure/" target="new">
                                     Home Page
                                 </a>
                             </li>

--- a/src/templates/info_panel_template.html
+++ b/src/templates/info_panel_template.html
@@ -14,8 +14,8 @@
                 <% }) %>
             </td></tr>
             <tr><td>
-                <div class="col-sm-6"><small><strong>Image ID</strong>:</small></div>
-                <div class="col-sm-6">
+                <div class="col-sm-5"><small><strong>Image ID</strong>:</small></div>
+                <div class="col-sm-7">
                     <small><%= imageId %></small>
                     <button type="button"
                             style="position:absolute; top:0px; right:0px"
@@ -25,17 +25,17 @@
                     </button>
                 </div>
 
-                <div class="col-sm-6"><small><strong>Dimensions (XY)</strong>:</small></div>
-                <div class="col-sm-6"><small><%= orig_width %> x <%= orig_height %></small></div>
+                <div class="col-sm-5"><small><strong>Dimensions (XY)</strong>:</small></div>
+                <div class="col-sm-7"><small><%= orig_width %> x <%= orig_height %></small></div>
 
-                <div class="col-sm-6"><small><strong>Z-sections</strong>:</small></div>
-                <div class="col-sm-6"><small><%= sizeZ %></small></div>
+                <div class="col-sm-5"><small><strong>Z-sections</strong>:</small></div>
+                <div class="col-sm-7"><small><%= sizeZ %></small></div>
                 <div class="clearfix"></div>
-                <div class="col-sm-6"><small><strong>Timepoints</strong>:</small></div>
-                <div class="col-sm-6"><small><%= sizeT %></small></div>
+                <div class="col-sm-5"><small><strong>Timepoints</strong>:</small></div>
+                <div class="col-sm-7"><small><%= sizeT %></small></div>
                 <div class="clearfix"></div>
-                <div class="col-sm-6"><small><strong>Channels</strong>:</small></div>
-                <div class="col-sm-6"><small>
+                <div class="col-sm-5"><small><strong>Channels</strong>:</small></div>
+                <div class="col-sm-7"><small>
                     <% _.each(channel_labels, function(c, i) {
                         print(_.escape(c)); print((i < channels.length-1) ? ", " : "");
                     }); %>

--- a/src/templates/info_panel_template.html
+++ b/src/templates/info_panel_template.html
@@ -28,8 +28,11 @@
                 <div class="col-sm-6"><small><strong>Dimensions (XY)</strong>:</small></div>
                 <div class="col-sm-6"><small><%= orig_width %> x <%= orig_height %></small></div>
 
-                <div class="col-sm-6"><small><strong>Z-sections/Timepoints</strong>:</small></div>
-                <div class="col-sm-6"><small><%= sizeZ %> x <%= sizeT %></small></div>
+                <div class="col-sm-6"><small><strong>Z-sections</strong>:</small></div>
+                <div class="col-sm-6"><small><%= sizeZ %></small></div>
+                <div class="clearfix"></div>
+                <div class="col-sm-6"><small><strong>Timepoints</strong>:</small></div>
+                <div class="col-sm-6"><small><%= sizeT %></small></div>
                 <div class="clearfix"></div>
                 <div class="col-sm-6"><small><strong>Channels</strong>:</small></div>
                 <div class="col-sm-6"><small>


### PR DESCRIPTION
A couple of minor fixes found in testing at https://docs.google.com/spreadsheets/d/1qdOAv0wUgAVHEtlVroOwkeNUoNwst-APSPFJk6-3Sz8

To test:
 - Check that ```Help -> Home page``` and ```Help -> About``` then homepage link both go to https://www.openmicroscopy.org/omero/figure/
 - Check that info tab can display big image sizes without overlapping the Edit button (size Z and size T now on separated rows)

![screen shot 2018-04-16 at 14 16 49](https://user-images.githubusercontent.com/900055/38811196-daa33df2-4180-11e8-99e2-6500cc758266.png)
/edit#gid=0


