### PR TITLE
loading spinner

### DIFF
--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -739,7 +739,7 @@
 
     .navbar-right .glyphicon-refresh, .imgContainer .glyphicon-refresh {
         animation: spin 2s linear infinite;
-        padding: 1px 2px 5px 2px;
+        padding: 1px 2px 2px 2px;
     }
 
     .imgContainer .glyphicon-refresh {

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -707,6 +707,7 @@
                     <div class="btn-group" style="margin-right:20px">
                         <button type="button" class="btn btn-sm btn-default" data-toggle="modal" data-target="#addImagesModal" title="Add images to figure">
                             Add Image
+                            <span id="addImagesSpinner" class="glyphicon glyphicon-refresh" title="Loading images..." style="display: none"></span>
                         </button>
                         <button type="button" class="btn btn-sm btn-default delete_panel" title="Delete selected panels">
                             Delete

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -28,6 +28,7 @@
             'height_mm': 297,
             'legend': '',       // Figure legend in markdown format.
             'legend_collapsed': true,   // collapse or expand legend
+            'loading_count': 0,         // images being loaded (show spinner if > 0)
         },
 
         initialize: function() {
@@ -284,6 +285,8 @@
                 index = 0;
             }
 
+            this.set('loading_count', this.get('loading_count') + 1);
+
             // Get the json data for the image...
             $.ajax({
                 url: imgDataUrl,
@@ -291,6 +294,8 @@
                 dataType: dataType,
                 // work with the response
                 success: function( data ) {
+
+                    self.set('loading_count', self.get('loading_count') - 1);
 
                     coords.spacer = coords.spacer || data.size.width/20;
                     var full_width = (coords.colCount * (data.size.width + coords.spacer)) - coords.spacer,
@@ -349,6 +354,7 @@
                 },
 
                 error: function(event) {
+                    self.set('loading_count', self.get('loading_count') - 1);
                     alert("Image not found on the server, " +
                         "or you don't have permission to access it at " + imgDataUrl);
                 },

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -69,6 +69,8 @@
             this.listenTo(this.model, 'change:page_color', this.render);
             this.listenTo(this.model, 'change:page_color', this.renderPanels);
 
+            this.listenTo(this.model, 'change:loading_count', this.renderLoadingSpinner);
+
             // refresh current UI
             this.renderZoom();
 
@@ -716,6 +718,14 @@
             var page_color = this.model.get('page_color');
             var view = new PanelView({model:panel, page_color:page_color});
             this.$figure.append(view.render().el);
+        },
+
+        renderLoadingSpinner: function() {
+            if (this.model.get('loading_count') > 0) {
+                $("#addImagesSpinner").show();
+            } else {
+                $("#addImagesSpinner").hide();
+            }
         },
 
         renderFigureName: function() {

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -142,8 +142,8 @@
             }
             this.$img_panel.one("load", function(){
                 $(".glyphicon-refresh", this.$el).hide();
-                $(this).show();
-            });
+                this.$img_panel.show();
+            }.bind(this));
 
             var src = this.model.get_img_src();
             this.$img_panel.attr('src', src);


### PR DESCRIPTION
Show a spinner while images are loading, from internal testing feedback at https://docs.google.com/spreadsheets/d/1qdOAv0wUgAVHEtlVroOwkeNUoNwst-APSPFJk6-3Sz8/edit#gid=0

Needs some thought about where and how big/obvious etc to show a spinner.
Currently this is quite subtle spinner in the Add Image button, similar to the figure export spinner.
This is not very obvious, but would probably be noticed by a user wondering whether anything is happening when loading takes a long time.

![screen shot 2018-04-17 at 11 11 47](https://user-images.githubusercontent.com/900055/38863630-2ab7d302-4230-11e8-8be0-1369b57bbef9.png)
