### PR TITLE
Dont scale line widths on zoom

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function (grunt) {
             expand: true,
             cwd: 'node_modules/@openmicroscopy/shape-editor/dist/js',
             src: 'shape-editor.js',
-            dest: 'omero_figure/static/figure/3rdparty/shape-editor-3.1.1'
+            dest: 'omero_figure/static/figure/3rdparty/shape-editor-4.0.0'
           },
         ]
       },

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -284,7 +284,7 @@ class ShapeToPdfExport(object):
         self.canvas.setStrokeColorRGB(r, g, b)
         self.canvas.setFillColorRGB(r, g, b)
 
-        head_size = (stroke_width * 2) + 20
+        head_size = (stroke_width * 4) + 5
         dx = x2 - x1
         dy = y2 - y1
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -475,7 +475,7 @@ class ShapeToPilExport(object):
         y1 = start['y']
         x2 = end['x']
         y2 = end['y']
-        head_size = ((shape['strokeWidth'] * 2) + 20)
+        head_size = ((shape['strokeWidth'] * 4) + 5)
         head_size = scale_to_export_dpi(head_size)
         stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
         rgb = ShapeToPdfExport.get_rgb(shape['strokeColor'])

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -663,7 +663,8 @@ class FigureExport(object):
                     page_coords_width = float(p.get('width'))
                     stroke_width_scale = page_coords_width/image_pixels_width
                     for shape in p['shapes']:
-                        stroke_width = shape.get('strokeWidth', 1) * stroke_width_scale
+                        stroke_width = shape.get('strokeWidth', 1)
+                        stroke_width = stroke_width * stroke_width_scale
                         # Set stroke-width to 0.25, 0.5, 0.75, 1 or greater
                         if stroke_width > 0.875:
                             stroke_width = int(round(stroke_width))

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -663,9 +663,17 @@ class FigureExport(object):
                     page_coords_width = float(p.get('width'))
                     stroke_width_scale = page_coords_width/image_pixels_width
                     for shape in p['shapes']:
-                        stroke_width = int(round(shape.get('strokeWidth', 1) *
-                                                 stroke_width_scale))
-                        stroke_width = max(stroke_width, 1)
+                        stroke_width = shape.get('strokeWidth', 1) * stroke_width_scale
+                        # Set stroke-width to 0.25, 0.5, 0.75, 1 or greater
+                        if stroke_width > 0.875:
+                            stroke_width = int(round(stroke_width))
+                        elif stroke_width > 0.625:
+                            stroke_width = 0.75
+                        elif stroke_width > 0.375:
+                            stroke_width = 0.5
+                        else:
+                            stroke_width = 0.25
+                        print 'strokewidth', shape['strokeWidth'], stroke_width
                         shape['strokeWidth'] = stroke_width
         return figure_json
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -88,7 +88,7 @@ processing steps:
 
 def scale_to_export_dpi(pixels):
     """
-    Origianl figure coordinates assume 72 dpi figure, but we want to
+    Original figure coordinates assume 72 dpi figure, but we want to
     export at 300 dpi, so everything needs scaling accordingly
     """
     return pixels * 300/72

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -632,7 +632,7 @@ class FigureExport(object):
         figure_json_string = script_params['Figure_JSON']
         # Since unicode can't be wrapped by rstring
         figure_json_string = figure_json_string.decode('utf8')
-        self.figure_json = self.version_transform_JSON(
+        self.figure_json = self.version_transform_json(
             json.loads(figure_json_string))
 
         n = datetime.now()
@@ -646,7 +646,7 @@ class FigureExport(object):
         self.page_width = self.figure_json['paper_width']
         self.page_height = self.figure_json['paper_height']
 
-    def version_transform_JSON(self, figure_json):
+    def version_transform_json(self, figure_json):
 
         v = figure_json.get('version')
         if v < 3:
@@ -666,7 +666,7 @@ class FigureExport(object):
                         stroke_width = int(round(shape.get('strokeWidth', 1) *
                                                  stroke_width_scale))
                         stroke_width = max(stroke_width, 1)
-                        shape['strokeWidth'] = stroke_width;
+                        shape['strokeWidth'] = stroke_width
         return figure_json
 
     def get_zip_name(self):

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -973,15 +973,6 @@
     .polyline-icon{
         background-image: url("../images/polyline-icon-16.png");
     }
-    .linewidthOption {
-        display: inline-block;
-        width: 25px;
-        background: black;
-        margin: 0 5px;
-    }
-    .line-width .linewidthOption {
-        max-height: 15px;
-    }
     .roiModalRoiItem {
         cursor: pointer;
     }

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -958,7 +958,7 @@
     <script src="{% static 'figure/3rdparty/bootstrap-3.0.0/js/bootstrap.js' %}"></script>
     <script src="{% static 'figure/3rdparty/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js' %}"></script>
     <script src="{% static 'figure/3rdparty/markdown-browser-0.6.0-beta1/markdown.min.js' %}"></script>
-    <script src="{% static 'figure/3rdparty/shape-editor-3.1.1/shape-editor.js' %}"></script>
+    <script src="{% static 'figure/3rdparty/shape-editor-4.0.0/shape-editor.js' %}"></script>
 
     <!-- underscore templates at static/figure/templates are compiled with '$ grunt jst' -->
     <script src="{% static 'figure/templates.js' %}?version={{ version }}"></script>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "grunt-replace": "^0.11.0"
   },
   "dependencies": {
-    "@openmicroscopy/shape-editor": "^3.1.1"
+    "@openmicroscopy/shape-editor": "^4.0.0"
   }
 }

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -149,8 +149,15 @@
                         var strokeWidthScale = pageCoordsWidth/imagePixelsWidth;
                         p.shapes = p.shapes.map(function(shape){
                             var strokeWidth = shape.strokeWidth || 1;
-                            strokeWidth = parseInt(Math.round(strokeWidth * strokeWidthScale));
-                            strokeWidth = Math.max(strokeWidth, 1);
+                            strokeWidth = strokeWidth * strokeWidthScale;
+                            // Set stroke-width to 0.25, 0.5, 1 or greater
+                            if (strokeWidth > 0.7) {
+                                strokeWidth = parseInt(Math.round(strokeWidth));
+                            } else if (strokeWidth > 0.375) {
+                                strokeWidth = 0.5;
+                            } else {
+                                strokeWidth = 0.25;
+                            }
                             shape.strokeWidth = strokeWidth;
                             return shape;
                         });

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -150,9 +150,11 @@
                         p.shapes = p.shapes.map(function(shape){
                             var strokeWidth = shape.strokeWidth || 1;
                             strokeWidth = strokeWidth * strokeWidthScale;
-                            // Set stroke-width to 0.25, 0.5, 1 or greater
-                            if (strokeWidth > 0.7) {
+                            // Set stroke-width to 0.25, 0.5, 0.75, 1 or greater
+                            if (strokeWidth > 0.875) {
                                 strokeWidth = parseInt(Math.round(strokeWidth));
+                            } else if (strokeWidth > 0.625) {
+                                strokeWidth = 0.75;
                             } else if (strokeWidth > 0.375) {
                                 strokeWidth = 0.5;
                             } else {

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -140,6 +140,21 @@
                         p.min_export_dpi = p.export_dpi;
                         delete p.export_dpi;
                     }
+                    // update strokeWidth to page pixels/coords instead of
+                    // image pixels. Scale according to size of panel and zoom
+                    if (p.shapes && p.shapes.length > 0) {
+                        var panel = new Panel(p);
+                        var imagePixelsWidth = panel.getViewportAsRect().width;
+                        var pageCoordsWidth = panel.get('width');
+                        var strokeWidthScale = pageCoordsWidth/imagePixelsWidth;
+                        p.shapes = p.shapes.map(function(shape){
+                            var strokeWidth = shape.strokeWidth || 1;
+                            strokeWidth = parseInt(Math.round(strokeWidth * strokeWidthScale));
+                            strokeWidth = Math.max(strokeWidth, 1);
+                            shape.strokeWidth = strokeWidth;
+                            return shape;
+                        });
+                    }
                 });
             }
 

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -89,7 +89,7 @@
         changeLineWidth: function() {
             var width = $('button.line-width span:first', this.$el).attr('data-line-width'),
                 sel = this.model.getSelected();
-            width = parseInt(width, 10);
+            width = parseFloat(width, 10);
 
             sel.forEach(function(panel){
                 panel.setROIStrokeWidth(width);

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -349,7 +349,7 @@ var RoiModalView = Backbone.View.extend({
                 sel = this.shapeManager.getSelectedShapes().length > 0,
                 toPaste = this.model.get('clipboard'),
                 windows = navigator.platform.toUpperCase().indexOf('WIN') > -1,
-                lineWidths = [0.25,0.5,1,2,3,4,5,7,10,15,20,30];
+                lineWidths = [0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30];
             color = color ? color.replace("#", "") : 'FFFFFF';
             toPaste = (toPaste && (toPaste.SHAPES || toPaste.CROP));
 

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -66,9 +66,8 @@ var RoiModalView = Backbone.View.extend({
                     self.shapeManager.setShapesJson(shapesJson);
                 }
 
-                // Default line width depends on image size
-                var lw = self.m.is_big_image() ? 30 : 2;
-                self.shapeManager.setStrokeWidth(lw);
+                // Default line width
+                self.shapeManager.setStrokeWidth(1);
 
                 // remove any previous OMERO ROIs
                 $("#roiModalRoiList table").empty();
@@ -353,10 +352,6 @@ var RoiModalView = Backbone.View.extend({
                 lineWidths = [1,2,3,4,5,7,10,15,20,30];
             color = color ? color.replace("#", "") : 'FFFFFF';
             toPaste = (toPaste && (toPaste.SHAPES || toPaste.CROP));
-            if (this.m.is_big_image()) {
-                // Add thicker line options: 50, 100,
-                lineWidths.splice(lineWidths.length, 0, 50, 100);
-            }
 
             var json = {'state': state,
                         'lineWidths': lineWidths,

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -268,7 +268,7 @@ var RoiModalView = Backbone.View.extend({
 
         changeLineWidth: function(event) {
             var lineWidth = $("span:first", event.target).attr('data-line-width');
-            lineWidth = parseInt(lineWidth, 10);
+            lineWidth = parseFloat(lineWidth, 10);
             this.shapeManager.setStrokeWidth(lineWidth);
         },
 
@@ -349,7 +349,7 @@ var RoiModalView = Backbone.View.extend({
                 sel = this.shapeManager.getSelectedShapes().length > 0,
                 toPaste = this.model.get('clipboard'),
                 windows = navigator.platform.toUpperCase().indexOf('WIN') > -1,
-                lineWidths = [1,2,3,4,5,7,10,15,20,30];
+                lineWidths = [0.25,0.5,1,2,3,4,5,7,10,15,20,30];
             color = color ? color.replace("#", "") : 'FFFFFF';
             toPaste = (toPaste && (toPaste.SHAPES || toPaste.CROP));
 

--- a/src/templates/rois_form_template.html
+++ b/src/templates/rois_form_template.html
@@ -55,7 +55,7 @@
         </button>
         <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
 
-            <% _.each([0.25,0.5,1,2,3,4,5,7,10,15,20,30],function(p){ %>
+            <% _.each([0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30],function(p){ %>
                 <li><a href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
             <% }); %>
 

--- a/src/templates/rois_form_template.html
+++ b/src/templates/rois_form_template.html
@@ -50,14 +50,14 @@
         <button type="button" class="line-width btn btn-default btn-sm dropdown-toggle" title="Line Width: <%= lineWidth %>"
             <% if (roiCount === 0) print('disabled') %>
             data-toggle="dropdown">
-            <span data-line-width="<%= lineWidth %>" class='linewidthOption' style='height:<%= lineWidth %>px; width:20px'></span>
+            <span data-line-width="<%= lineWidth %>"><%= lineWidth %> pt</span>
             <span class="caret"></span>
         </button>
         <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
 
-            <% _.each([1,2,3,4,5,7,10,15,20,30],function(p){
-                print ("<li><a href='#'>"+p+"<span title='Line Width: "+p+"' data-line-width='"+p+"' class='linewidthOption' style='height:"+p+"px; width:20px'></span></a></li>")
-            }); %>
+            <% _.each([0.25,0.5,1,2,3,4,5,7,10,15,20,30],function(p){ %>
+                <li><a href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
+            <% }); %>
 
         </ul>
     </div>

--- a/src/templates/shapes/shape_toolbar_template.html
+++ b/src/templates/shapes/shape_toolbar_template.html
@@ -62,15 +62,13 @@
 <div class="btn-group">
     <button type="button" class="line-width btn btn-default dropdown-toggle" title="Line Width: <%= lineWidth %>"
         data-toggle="dropdown">
-        <span data-line-width="<%= lineWidth %>" class='linewidthOption' style='height:<%= lineWidth %>px'></span>
+        <span data-line-width="<%= lineWidth %>"><%= lineWidth %> pt</span>
         <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
-
-        <% _.each(lineWidths,function(p){
-            print ("<li><a href='#'>"+p+"<span title='Line Width: "+p+"' data-line-width='"+p+"' class='linewidthOption' style='height:"+p+"px'></span></a></li>")
-        }); %>
-
+    <ul class="dropdown-menu dropdownSelect lineWidth" style="min-width: 0" role="menu">
+        <% _.each(lineWidths,function(p){ %>
+            <li><a href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
+        <% }); %>
     </ul>
 </div>
 


### PR DESCRIPTION
The problem we find with big images is that the current strategy of scaling stroke-widths of ROI shapes to the image pixels means that when you zoom out, the lines get thinner and are invisible for Big Images, unless you set a stroke width of 100!

Also, the scaling of stroke-widths with images is inconsistent with OMERO.iviewer, so thin lines drawn on a Big Image in iviewer are invisible in figure.

This PR includes https://github.com/ome/shape-editor/pull/11 and means that when we zoom an image, the stroke widths stay the same. NB: since shape-editor is not released yet, I have copied the code over to test. When happy, can revert the TEMP commit and update version.
This means that all shapes on figure panels are shown on the figure at the same stroke-width, even when a panel is resized.
Export script is updated so that exported PDF / TIFF match what is in figure web UI.

When upgrading from older versions, we try to scale the line thickness to appear the same.

We now support line widths of 0.25 and 0.5 (previous minimum was 1).

