### PR TITLE
save before file open

### DIFF
--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -394,8 +394,8 @@
                     ["Cancel", "Don't Save", saveBtnTxt],
                     function(btnTxt){
                         if (btnTxt === saveBtnTxt) {
-                            self.save_figure();
-                            callback();
+                            // List files after saving current file
+                            self.save_figure({success: callback});
                         } else if (btnTxt === "Don't Save") {
                             self.model.set("unsaved", false);
                             callback();


### PR DESCRIPTION
As reported in testing sheet: https://docs.google.com/spreadsheets/d/1qdOAv0wUgAVHEtlVroOwkeNUoNwst-APSPFJk6-3Sz8/edit#gid=0
If a file is renamed and not saved, then File > Open (choose to save changes) doesn't show the new name in the list.
Also, if a New file is unsaved, then File > Open (choose to save new file) doesn't show the new file in the list.
Both these cases should be fixed and the new changes should be shown in the file list, since we now *wait* for the save call to return before we list files (previously, both calls were made asynchronously).

cc @pwalczysko 