### PR TITLE
file_open_menu

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -606,13 +606,13 @@
                                 </a>
                             </li>
                             <li class="save_as">
-                                <a href="#">Save A Copy...</a>
+                                <a href="#">Save a Copy...</a>
                             </li>
                             <li class="export_json">
-                                <a href="#">Export as json</a>
+                                <a href="#">Export as JSON</a>
                             </li>
                             <li class="import_json">
-                                <a href="#">Import from json...</a>
+                                <a href="#">Import from JSON...</a>
                             </li>
                             <li class="delete_figure">
                                 <a href="#">Delete</a>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -589,19 +589,18 @@
                         <ul class="active dropdown-menu">
                             <li class="new_figure">
                                 <a href="#">
-                                    <span class="pull-right">⌘N</span>
                                     New
                                 </a>
                             </li>
                             <li class="open_figure">
                                 <a href="#">
-                                    <span class="pull-right">⌘O</span>
+                                    <span class="pull-right">Ctrl+O</span>
                                     Open...
                                 </a>
                             </li>
                             <li class="save_figure disabled">
                                 <a href="#">
-                                    <span class="pull-right">⌘S</span>
+                                    <span class="pull-right">Ctrl+S</span>
                                     Save
                                 </a>
                             </li>
@@ -633,25 +632,25 @@
                             <!-- We add <a> to undo/redo to enable. See undo.js -->
                             <li class="undo disabled">
                                 <a href="#">
-                                    <span class="pull-right">⌘Z</span>
+                                    <span class="pull-right">Ctrl+Z</span>
                                     Undo
                                 </a>
                             </li>
                             <li class="redo disabled">
                                 <a href="#">
-                                    <span class="pull-right">⌘Y</span>
+                                    <span class="pull-right">Ctrl+Y</span>
                                     Redo
                                 </a>
                             </li>
                             <li class="copy disabled">
                                 <a href="#">
-                                    <span class="pull-right">⌘C</span>
+                                    <span class="pull-right">Ctrl+C</span>
                                     Copy
                                 </a>
                             </li>
                             <li class="paste disabled">
                                 <a href="#">
-                                    <span class="pull-right">⌘V</span>
+                                    <span class="pull-right">Ctrl+V</span>
                                     Paste
                                 </a>
                             </li>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -591,7 +591,7 @@
                                 <a href="#">New ⌘N</a>
                             </li>
                             <li class="open_figure">
-                                <a href="#">Open ⌘O</a>
+                                <a href="#">Open... ⌘O</a>
                             </li>
                             <li class="save_figure disabled">
                                 <a href="#">Save ⌘S</a>
@@ -603,7 +603,7 @@
                                 <a href="#">Export as json</a>
                             </li>
                             <li class="import_json">
-                                <a href="#">Import from json</a>
+                                <a href="#">Import from json...</a>
                             </li>
                             <li class="delete_figure">
                                 <a href="#">Delete</a>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -589,20 +589,20 @@
                         <ul class="active dropdown-menu">
                             <li class="new_figure">
                                 <a href="#">
-                                    New
                                     <span class="pull-right">⌘N</span>
+                                    New
                                 </a>
                             </li>
                             <li class="open_figure">
                                 <a href="#">
-                                    Open...
                                     <span class="pull-right">⌘O</span>
+                                    Open...
                                 </a>
                             </li>
                             <li class="save_figure disabled">
                                 <a href="#">
-                                    Save
                                     <span class="pull-right">⌘S</span>
+                                    Save
                                 </a>
                             </li>
                             <li class="save_as">
@@ -633,26 +633,26 @@
                             <!-- We add <a> to undo/redo to enable. See undo.js -->
                             <li class="undo disabled">
                                 <a href="#">
-                                    Undo
                                     <span class="pull-right">⌘Z</span>
+                                    Undo
                                 </a>
                             </li>
                             <li class="redo disabled">
                                 <a href="#">
-                                    Redo
                                     <span class="pull-right">⌘Y</span>
+                                    Redo
                                 </a>
                             </li>
                             <li class="copy disabled">
                                 <a href="#">
-                                    Copy
                                     <span class="pull-right">⌘C</span>
+                                    Copy
                                 </a>
                             </li>
                             <li class="paste disabled">
                                 <a href="#">
-                                    Paste
                                     <span class="pull-right">⌘V</span>
+                                    Paste
                                 </a>
                             </li>
 

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -420,11 +420,11 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="addImagesLabel">Export as json</h4>
+                    <h4 class="modal-title" id="addImagesLabel">Export as JSON</h4>
                 </div>
                 <form class="addImagesForm" role="form">
                     <div class="modal-body">
-                        <p>The current Figure is entirely defined by the json data below.
+                        <p>The current Figure is entirely defined by the JSON data below.
                         </p>
                         <div class="form-group" style="margin-top: 15px; margin-bottom: 0px">
                             <textarea class="form-control" rows="15"></textarea>
@@ -443,11 +443,11 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="addImagesLabel">Import from json</h4>
+                    <h4 class="modal-title" id="addImagesLabel">Import from JSON</h4>
                 </div>
                 <form class="importJsonForm" role="form">
                     <div class="modal-body">
-                        <p>Paste the json data for the Figure into the text box below.
+                        <p>Paste the JSON data for the Figure into the text box below.
                         </p>
                         <div class="form-group" style="margin-top: 15px; margin-bottom: 0px">
                             <textarea class="form-control" rows="15"></textarea>
@@ -608,7 +608,7 @@
                                 <a href="#">Save a Copy...</a>
                             </li>
                             <li class="export_json">
-                                <a href="#">Export as JSON</a>
+                                <a href="#">Export as JSON...</a>
                             </li>
                             <li class="import_json">
                                 <a href="#">Import from JSON...</a>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -588,13 +588,22 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">File <b class="caret"></b></a>
                         <ul class="active dropdown-menu">
                             <li class="new_figure">
-                                <a href="#">New ⌘N</a>
+                                <a href="#">
+                                    New
+                                    <span class="pull-right">⌘N</span>
+                                </a>
                             </li>
                             <li class="open_figure">
-                                <a href="#">Open... ⌘O</a>
+                                <a href="#">
+                                    Open...
+                                    <span class="pull-right">⌘O</span>
+                                </a>
                             </li>
                             <li class="save_figure disabled">
-                                <a href="#">Save ⌘S</a>
+                                <a href="#">
+                                    Save
+                                    <span class="pull-right">⌘S</span>
+                                </a>
                             </li>
                             <li class="save_as">
                                 <a href="#">Save A Copy...</a>
@@ -623,16 +632,28 @@
                         <ul class="active dropdown-menu">
                             <!-- We add <a> to undo/redo to enable. See undo.js -->
                             <li class="undo disabled">
-                                <a href="#">Undo ⌘Z</a>
+                                <a href="#">
+                                    Undo
+                                    <span class="pull-right">⌘Z</span>
+                                </a>
                             </li>
                             <li class="redo disabled">
-                                <a href="#">Redo ⌘Y</a>
+                                <a href="#">
+                                    Redo
+                                    <span class="pull-right">⌘Y</span>
+                                </a>
                             </li>
                             <li class="copy disabled">
-                                <a href="#">Copy ⌘C</a>
+                                <a href="#">
+                                    Copy
+                                    <span class="pull-right">⌘C</span>
+                                </a>
                             </li>
                             <li class="paste disabled">
-                                <a href="#">Paste ⌘V</a>
+                                <a href="#">
+                                    Paste
+                                    <span class="pull-right">⌘V</span>
+                                </a>
                             </li>
 
                          </ul>

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -760,7 +760,7 @@
             }
         },
 
-        createLabelsFromTags(options) {
+        createLabelsFromTags: function(options) {
             // Loads Tags for selected images and creates labels
             var image_ids = this.map(function(s){return s.get('imageId')})
             image_ids = "image=" + image_ids.join("&image=");

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -153,22 +153,11 @@ $(function(){
     $('.btn-xs').tooltip({container: 'body', placement:'top', toggle:"tooltip"});
 
 
-    // If we're on Windows, update tool-tips for keyboard short cuts:
-    if (navigator.platform.toUpperCase().indexOf('WIN') > -1) {
-        $('.btn-sm').each(function(){
-            var $this = $(this),
-                tooltip = $this.attr('data-original-title');
-            if ($this.attr('data-original-title')) {
-                $this.attr('data-original-title', tooltip.replace("⌘", "Ctrl+"));
-            }
-        });
-        // refresh tooltips
-        $('.btn-sm, .navbar-header').tooltip({container: 'body', placement:'bottom', toggle:"tooltip"});
-
-        // Also update text in dropdown menus
+    // If we're on Mac, update dropdown menus for keyboard short cuts:
+    if (navigator.platform.toUpperCase().indexOf('MAC') > -1) {
         $("ul.dropdown-menu li a span").each(function(){
             var $this = $(this);
-                $this.text($this.text().replace("⌘", "Ctrl+"));
+                $this.text($this.text().replace("Ctrl+", "⌘"));
         });
     }
 

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -166,7 +166,7 @@ $(function(){
         $('.btn-sm, .navbar-header').tooltip({container: 'body', placement:'bottom', toggle:"tooltip"});
 
         // Also update text in dropdown menus
-        $("ul.dropdown-menu li a").each(function(){
+        $("ul.dropdown-menu li a span").each(function(){
             var $this = $(this);
                 $this.text($this.text().replace("⌘", "Ctrl+"));
         });


### PR DESCRIPTION
From comment on testing sheet
https://docs.google.com/spreadsheets/d/1qdOAv0wUgAVHEtlVroOwkeNUoNwst-APSPFJk6-3Sz8/edit#gid=0
"* File menu. When clicking on an item, a dialog pops up. To be consistent with Save a Copy...
All entries should have ... e.g. Open ..."

This PR adds the 3 dots to the commands which are incomplete (need other options chosen in a dialog). 
These are Open... and Import from JSON...

Also, improved layout of the drop-down menu options that have keyboard shortcuts, aligning the shortcut keys to the right of each menu.

To test:
 - Check the File and Edit menus looks OK on Mac
 - Check that on Windows the shortcut keys show ```Ctrl+N``` instead of apple key.

![screen shot 2018-04-23 at 12 35 05](https://user-images.githubusercontent.com/900055/39124288-d2b6bfb6-46f2-11e8-9476-ecc0786127aa.png)
