### PR TITLE
Z-projection disabled big images

### DIFF
--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1389,8 +1389,10 @@
                 // save this value to init rotation slider etc
                 this.rotation = avg_rotation;
 
+                var anyBig = this.models.any(function(m){return m.is_big_image()});
                 // if all panels have sizeZ == 1, don't allow z_projection
-                z_projection_disabled = (sum_sizeZ === this.models.length);
+                // Don't currently support Z_projection on Big images.
+                z_projection_disabled = ((sum_sizeZ === this.models.length) || anyBig);
 
                 html = this.template({
                     'z_projection_disabled': z_projection_disabled,


### PR DESCRIPTION
Since BlitzGateway methods for rendering big images don't yet support Z-projection, we disable the Z-projection button if any selected images are Big.

To test:
 - Need a Big Image with Z-stack.
 - Whenever any Big image is selected, Z-projection button should be disabled.

cc @jburel 