### PR TITLE
Fix Arrow strokeWidth for PDF export

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -288,7 +288,6 @@ class ShapeToPdfExport(object):
         dx = x2 - x1
         dy = y2 - y1
 
-        stroke_width = stroke_width * self.scale
         self.canvas.setLineWidth(stroke_width)
 
         p = self.canvas.beginPath()


### PR DESCRIPTION
Missed this from before.

To test:
 - draw arrows of various strokeWidths
 - export as PDF
 - check that stroke-widths look correct compared with web view

Screenshot shows web (left), PDF before fix (centre) and PDF after fix (right)

![screen shot 2018-05-16 at 14 38 55](https://user-images.githubusercontent.com/900055/40120393-f9283888-5916-11e8-8466-05888fdd1de0.png)
