### PR TITLE
Add Dataset_ID param to export script

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2012,7 +2012,8 @@ class OmeroExport(TiffExport):
             dataset = self.conn.getObject("Dataset", dataset_id)
         else:
             for panel in self.figure_json['panels']:
-                parent = self.conn.getObject('Image', panel['imageId']).getParent()
+                parent = self.conn.getObject('Image',
+                                             panel['imageId']).getParent()
                 if parent is not None and parent.OMERO_CLASS == 'Dataset':
                     if parent.canLink():
                         dataset = parent
@@ -2106,7 +2107,7 @@ def run_script():
                        description="URL to the Figure"),
 
         scripts.Long("Dataset_ID",
-                       description="Dataset to add the new Image")
+                     description="Dataset to add the new Image")
     )
 
     try:

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2005,12 +2005,18 @@ class OmeroExport(TiffExport):
 
         # Try to get a Dataset
         dataset = None
-        for panel in self.figure_json['panels']:
-            parent = self.conn.getObject('Image', panel['imageId']).getParent()
-            if parent is not None and parent.OMERO_CLASS == 'Dataset':
-                if parent.canLink():
-                    dataset = parent
-                    break
+
+        dataset_id = self.script_params.get('Dataset_ID')
+        if dataset_id:
+            self.conn.SERVICE_OPTS.setOmeroGroup(-1)
+            dataset = self.conn.getObject("Dataset", dataset_id)
+        else:
+            for panel in self.figure_json['panels']:
+                parent = self.conn.getObject('Image', panel['imageId']).getParent()
+                if parent is not None and parent.OMERO_CLASS == 'Dataset':
+                    if parent.canLink():
+                        dataset = parent
+                        break
 
         # Need to specify group for new image
         group_id = self.conn.getEventContext().groupId
@@ -2097,7 +2103,10 @@ def run_script():
                        description="Name of the Pdf Figure"),
 
         scripts.String("Figure_URI",
-                       description="URL to the Figure")
+                       description="URL to the Figure"),
+
+        scripts.Long("Dataset_ID",
+                       description="Dataset to add the new Image")
     )
 
     try:


### PR DESCRIPTION
When exporting a Figure as a new Image in OMERO, this allows us to choose
a Dataset to add the new Image to (instead of using the same Dataset that images in the figure are in).
This isn't supported in the UI yet.

To test:
 - This can be tested in the Script menu...
 - Open a Figure to export and ```File -> Export as JSON```.
 - Select All and Copy the JSON.
 - Go to webclient, Run Script -> Figure scripts -> Figure to Pdf
     - Paste the JSON in first field
     - Select Export Option: "OMERO"
     - Enter a Dataset ID
     - Enter a URL in Webclient URI:  e.g.```http://localhost```
 - Run Script... Figure should be exported as new Image in the Dataset specified.
 - When run without Dataset ID specified, new Image should be put into Dataset from an Image in the figure.

cc @jstitlow