### PR TITLE
big image scalebar fix

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1118,7 +1118,16 @@ class FigureExport(object):
             ly = y + height - spacer
             align = "right"
 
-        pixels_length = sb['length'] / panel['pixel_size_x']
+        pixel_size_x = panel['pixel_size_x']
+
+        # If we previously calculated the zoom scale for big image rendering
+        # Use this again here to scale the pixel size
+        if 'zoom_level_scale' in panel:
+            scale = panel['zoom_level_scale']
+            pixel_size_x = pixel_size_x / scale
+
+        pixels_length = sb['length'] / pixel_size_x
+
         scale_to_canvas = panel['width'] / float(region_width)
         canvas_length = pixels_length * scale_to_canvas
 
@@ -1155,16 +1164,8 @@ class FigureExport(object):
         max_w, max_h = self.conn.getMaxPlaneSize()
         return image.getSizeX() * image.getSizeY() > max_w * max_h
 
-    def render_big_image_region(self, image, z, t, region, max_width):
-        """
-        Render region of a big image at an appropriate zoom level
-        so width < max_width
-        """
-
-        size_x = image.getSizeX()
-        size_y = image.getSizeY()
-        x = region['x']
-        y = region['y']
+    def get_zoom_level_scale(self, image, region, max_width):
+        """Calculate the scale and zoom level we want to use for big image."""
         width = region['width']
         height = region['height']
 
@@ -1188,6 +1189,25 @@ class FigureExport(object):
         # We need to use final rendered jpeg coordinates
         # Convert from original image coordinates by scaling
         scale = zm_levels[zm]
+        return scale, level
+
+    def render_big_image_region(self, image, panel, z, t, region, max_width):
+        """
+        Render region of a big image at an appropriate zoom level
+        so width < max_width
+        """
+        scale, level = self.get_zoom_level_scale(image, region, max_width)
+        # cache the 'zoom_level_scale', in the panel dict.
+        # since we need it for scalebar, and don't want to calculate again
+        # since rendering engine will be closed by then
+        panel['zoom_level_scale'] = scale
+
+        width = region['width']
+        height = region['height']
+        x = region['x']
+        y = region['y']
+        size_x = image.getSizeX()
+        size_y = image.getSizeY()
         x = int(x * scale)
         y = int(y * scale)
         width = int(width * scale)
@@ -1256,15 +1276,16 @@ class FigureExport(object):
                                'height': vp_h + extra_h}
             max_width = max_width * (viewport_region['width'] / vp_w)
 
-        pil_img = self.render_big_image_region(image, z, t, viewport_region,
-                                               max_width)
+        pil_img = self.render_big_image_region(image, panel, z, t,
+                                               viewport_region, max_width)
 
         # Optional rotation
         if rotation != 0 and pil_img is not None:
             w, h = pil_img.size
             # How much smaller is the scaled image compared to viewport?
             # This will be the same 'scale' used in render_big_image_region()
-            scale = float(w) / viewport_region['width']
+            # scale = float(w) / viewport_region['width']
+            scale = panel['zoom_level_scale']
             # The size we want to crop to
             crop_target_w = scale * vp_w
             crop_target_h = scale * vp_h

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1284,7 +1284,6 @@ class FigureExport(object):
             w, h = pil_img.size
             # How much smaller is the scaled image compared to viewport?
             # This will be the same 'scale' used in render_big_image_region()
-            # scale = float(w) / viewport_region['width']
             scale = panel['zoom_level_scale']
             # The size we want to crop to
             crop_target_w = scale * vp_w


### PR DESCRIPTION
Bug fix: See https://trello.com/c/S78nkV0c/203-bug-scalebars-in-exported-pdf-big-images (reported at https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8523&p=19515)

To test:
 - Check that scalebars are drawn correctly at various zoom levels of a big image.
 - I did this by drawing ROI lines of known length in iviewer, using the scalebar on the image.
 - Then add these Lines as ROIs in figure and add scalebars of corresponding length, e.g. screenshot below:
 - Add some scalebars to non-big images to check they still work OK.
 - Export to PDF & TIFF and check that scalebars show up at same level as in web.

<img width="816" alt="screen shot 2018-07-09 at 12 51 10" src="https://user-images.githubusercontent.com/900055/42448932-d0211736-8376-11e8-8858-3e7fad18be1b.png">