### PR TITLE
Additional export functionality

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -26,6 +26,7 @@ import os
 from os import path
 import zipfile
 from math import atan2, atan, sin, cos, sqrt, radians
+from copy import deepcopy
 
 from omero.model import ImageAnnotationLinkI, ImageI
 import omero.scripts as scripts
@@ -141,6 +142,8 @@ class ShapeToPdfExport(object):
                     self.draw_polygon(shape)
                 elif shape['type'] == "Polyline":
                     self.draw_polyline(shape)
+                elif shape['type'] == "Point":
+                    self.draw_point(shape)
 
     @staticmethod
     def get_rgb(color):
@@ -400,6 +403,12 @@ class ShapeToPdfExport(object):
 
         # Restore coordinates, rotation etc.
         self.canvas.restoreState()
+
+    def draw_point(self, shape):
+        s = deepcopy(shape)
+        s['radiusX'] = 5 / self.scale
+        s['radiusY'] = 5 / self.scale
+        self.draw_ellipse(s)
 
 
 class ShapeToPilExport(object):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -637,7 +637,7 @@ class ShapeToPilExport(ShapeExport):
         temp_draw = ImageDraw.Draw(temp_image)
 
         # if fill color, draw polygon without outline first
-        if rgba[3]:
+        if closed and rgba[3]:
             temp_draw.polygon(points, fill=rgba, outline=(0, 0, 0, 0))
 
         # Draw all the lines (NB: polygon doesn't handle line width)

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -620,6 +620,7 @@ class ShapeToPilExport(ShapeExport):
             points.append(points[0])
 
         stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
+        buffer = int(ceil(stroke_width))
 
         # if fill, draw filled polygon without outline, then add line later
         # with correct stroke width
@@ -629,10 +630,10 @@ class ShapeToPilExport(ShapeExport):
         bounds = Bounds(*points).round()
         offset = (bounds.minx, bounds.miny)
         points = [
-            (point[0] - offset[0], point[1] - offset[1])
+            (point[0] - offset[0] + buffer, point[1] - offset[1] + buffer)
             for point in points
         ]
-        bounds.grow(ceil(stroke_width / 2.0)).round()
+        bounds.grow(buffer)
         temp_image = Image.new('RGBA', bounds.get_size())
         temp_draw = ImageDraw.Draw(temp_image)
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -665,7 +665,6 @@ class ShapeToPilExport(ShapeExport):
             temp_image, (bounds.minx, bounds.miny), mask=temp_image)
         self.draw_shape_label(shape, bounds)
 
-
     def draw_polygon(self, shape, closed=True):
         points = []
         for point in shape['points'].split(" "):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -287,7 +287,7 @@ class ShapeToPdfExport(ShapeExport):
 
     def draw_shape_label(self, shape, bounds):
         center = bounds.get_center()
-        text = cgi.escape(shape['text'])
+        text = cgi.escape(shape.get('text'))
         size = shape['fontSize'] * 2 / 3
         if not text or not center:
             return
@@ -543,7 +543,7 @@ class ShapeToPilExport(ShapeExport):
 
     def draw_shape_label(self, shape, bounds):
         center = bounds.get_center()
-        text = shape['text']
+        text = shape.get('text')
         size = int(shape['fontSize'] * 2.5)
         if not text or not center:
             return

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -650,9 +650,8 @@ class ShapeToPilExport(ShapeExport):
         x2 = end['x']
         y2 = end['y']
         stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
-        rgb = ShapeToPdfExport.get_rgb(shape['strokeColor'])
-
-        self.draw.line([(x1, y1), (x2, y2)], fill=rgb, width=int(stroke_width))
+        rgba = ShapeToPdfExport.get_rgba_int(shape['strokeColor'])
+        self.draw.line([(x1, y1), (x2, y2)], fill=rgba, width=int(stroke_width))
 
     def draw_ellipse(self, shape):
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -304,7 +304,8 @@ class ShapeToPdfExport(ShapeExport):
         )
         para = Paragraph(text, style)
         w, h = para.wrap(10000, 100)
-        para.drawOn(self.canvas, center[0] - w / 2, center[1] - h / 2 + size / 4)
+        para.drawOn(
+            self.canvas, center[0] - w / 2, center[1] - h / 2 + size / 4)
 
     def draw_line(self, shape):
         start = self.panel_to_page_coords(shape['x1'], shape['y1'])
@@ -506,7 +507,6 @@ class ShapeToPilExport(ShapeExport):
 
         super(ShapeToPilExport, self).__init__(panel)
 
-
     def get_panel_coords(self, shape_x, shape_y):
         """
         Convert coordinate from the image onto the panel.
@@ -654,7 +654,8 @@ class ShapeToPilExport(ShapeExport):
             temp_draw.ellipse((point[0] - r, point[1] - r,
                                point[0] + r, point[1] + r), fill=rgba)
 
-        self.pil_img.paste(temp_image, (bounds.minx, bounds.miny), mask=temp_image)
+        self.pil_img.paste(
+            temp_image, (bounds.minx, bounds.miny), mask=temp_image)
         self.draw_shape_label(shape, bounds)
 
     def draw_polyline(self, shape):
@@ -669,7 +670,8 @@ class ShapeToPilExport(ShapeExport):
         y2 = end['y']
         stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
         rgba = ShapeToPdfExport.get_rgba_int(shape['strokeColor'])
-        self.draw.line([(x1, y1), (x2, y2)], fill=rgba, width=int(stroke_width))
+        self.draw.line(
+            [(x1, y1), (x2, y2)], fill=rgba, width=int(stroke_width))
         self.draw_shape_label(shape, Bounds((x1, y1), (x2, y2)))
 
     def draw_ellipse(self, shape):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1787,6 +1787,9 @@ class FigureExport(object):
             alignment = TA_CENTER
             x = x - (para_width/2)
 
+        # set fully opaque background color to avoid transparent text
+        c.setFillColorRGB(0, 0, 0, 1)
+
         style_n = getSampleStyleSheet()['Normal']
         style = ParagraphStyle(
             'label',
@@ -1814,7 +1817,7 @@ class FigureExport(object):
         y2 = self.page_height - y2
         c = self.figure_canvas
         c.setLineWidth(width)
-        c.setStrokeColorRGB(red, green, blue)
+        c.setStrokeColorRGB(red, green, blue, 1)
         c.line(x, y, x2, y2,)
 
     def paste_image(self, pil_img, img_name, panel, page, dpi):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1851,6 +1851,8 @@ class FigureExport(object):
         pil_img.save(img_name)
         # Since coordinate system is 'bottom-up', convert from 'top-down'
         y = self.page_height - height - y
+        # set fill color alpha to fully opaque, since this impacts drawImage
+        self.figure_canvas.setFillColorRGB(0, 0, 0, alpha=1)
         self.figure_canvas.drawImage(img_name, x, y, width, height)
 
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -287,10 +287,10 @@ class ShapeToPdfExport(ShapeExport):
 
     def draw_shape_label(self, shape, bounds):
         center = bounds.get_center()
-        text = cgi.escape(shape.get('text'))
-        size = shape['fontSize'] * 2 / 3
+        text = cgi.escape(shape.get('text', ''))
         if not text or not center:
             return
+        size = shape.get('fontSize', 12) * 2 / 3
         r, g, b, a = self.get_rgba(shape['strokeColor'])
         # bump up alpha a bit to make text more readable
         rgba = (r, g, b, 0.5 + a / 2.0)
@@ -544,7 +544,7 @@ class ShapeToPilExport(ShapeExport):
     def draw_shape_label(self, shape, bounds):
         center = bounds.get_center()
         text = shape.get('text')
-        size = int(shape['fontSize'] * 2.5)
+        size = int(shape.get('fontSize', 12) * 2.5)
         if not text or not center:
             return
         r, g, b, a = self.get_rgba_int(shape['strokeColor'])

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -169,6 +169,15 @@ class ShapeExport(object):
         return (red, green, blue, alpha)
 
     @staticmethod
+    def get_rgba_int(color):
+        # Convert from E.g. '#ff0000ff' to (255, 0, 0, 1.0)
+        red = int(color[1:3], 16)
+        green = int(color[3:5], 16)
+        blue = int(color[5:7], 16)
+        alpha = int(color[7:9] or 'ff', 16)
+        return (red, green, blue, alpha)
+
+    @staticmethod
     def apply_transform(tf, point):
         return [
             point[0] * tf['A00'] + point[1] * tf['A01'] + tf['A02'],
@@ -610,7 +619,6 @@ class ShapeToPilExport(ShapeExport):
         rx = self.scale * shape['radiusX']
         ry = self.scale * shape['radiusY']
         rotation = (shape['rotation'] + self.panel['rotation']) * -1
-        rgb = ShapeToPdfExport.get_rgb(shape['strokeColor'])
 
         width = int((rx * 2) + w)
         height = int((ry * 2) + w)
@@ -618,8 +626,9 @@ class ShapeToPilExport(ShapeExport):
                                  (255, 255, 255, 0))
         ellipse_draw = ImageDraw.Draw(temp_ellipse)
         # Draw outer ellipse, then remove inner ellipse with full opacity
-        ellipse_draw.ellipse((0, 0, width, height), fill=rgb)
-        rgba = (255, 255, 255, 0)
+        rgba = ShapeToPdfExport.get_rgba_int(shape['strokeColor'])
+        ellipse_draw.ellipse((0, 0, width, height), fill=rgba)
+        rgba = self.get_rgba_int(shape.get('fillColor', '#00000000'))
         ellipse_draw.ellipse((w, w, width - w, height - w), fill=rgba)
         temp_ellipse = temp_ellipse.rotate(rotation, resample=Image.BICUBIC,
                                            expand=True)


### PR DESCRIPTION
This PR includes additional functionality for the PDF/TIFF export:

- Shape fills (fully transparent when not given)
- Alpha channel for stroke and fill colors (defaulting to fully opaque when not given)
- Rotated rectangles (by processing rectangles as a polygon)
- Point shapes (as small circles processed as ellipses)
- Shape labels

None of these changes should impact the current export behavior for a given figure, though I need to do some more thorough testing.

Especially shape label rendering will need some more work, but opening the PR now for early review.

