### PR TITLE
Don't show NaN for shape Z/T if undefined

### DIFF
--- a/src/templates/modal_dialogs/roi_modal_shape.html
+++ b/src/templates/modal_dialogs/roi_modal_shape.html
@@ -10,8 +10,16 @@
         <td>
             <span class="glyphicon <% if (shape.icon) { %><%= shape.icon %><% } %>"></span>
         </td>
-        <td><%= shape.theZ + 1 %> </td>
-        <td><%= shape.theT + 1 %> </td>
+        <td>
+            <% if (shape.theZ !== undefined) { %>
+                <%= shape.theZ + 1 %>
+            <% } %>
+        </td>
+        <td>
+            <% if (shape.theT !== undefined) { %>
+                <%= shape.theT + 1 %>
+            <% } %>
+        </td>
         <td>
             <% if (shape.icon) { %>
             <button type="button" class="addOmeroShape btn btn-success btn-sm"


### PR DESCRIPTION
Don't show NaN for shape Z/T if undefined.

To test:
 - Load ROIs with multiple shapes where Z / T are not defined.
 - Shapes should not show Z / T as NaN (should be blank)

cc @jburel 