### PR TITLE
Apply transform to rectangles when exporting via PIL

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -618,8 +618,8 @@ class ShapeToPilExport(ShapeExport):
         p = []
         t = shape.get('transform')
         for point in points:
-            point = self.apply_transform(t, point)
-            coords = self.get_panel_coords(*point)
+            transformed = self.apply_transform(t, point)
+            coords = self.get_panel_coords(*transformed)
             p.append((coords['x'], coords['y']))
         p.append(p[0])
         points = p

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -616,7 +616,9 @@ class ShapeToPilExport(ShapeExport):
             (shape['x'], shape['y'] + shape['height']),
         ]
         p = []
+        t = shape.get('transform')
         for point in points:
+            point = self.apply_transform(t, point)
             coords = self.get_panel_coords(*point)
             p.append((coords['x'], coords['y']))
         p.append(p[0])


### PR DESCRIPTION
https://github.com/ome/omero-figure/pull/306 introduced a bug that causes transformations not to be applied to rectangles when exporting via PIL.  It probably went undiscovered since rectangles usually don't have a transformation (rotation) applied.