### PR TITLE
export to omero description

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2214,6 +2214,16 @@ class OmeroExport(TiffExport):
         if legend is not None:
             description = "%s\n\n%s" % (description, legend)
 
+        img_ids = set()
+        lines = []
+        for p in self.figure_json['panels']:
+            iid = p['imageId']
+            if iid in img_ids:
+                continue    # ignore images we've already handled
+            img_ids.add(iid)
+            lines.append('- Image ID: %s %s' % (iid, p['name']))
+        description += "Contains images:\n%s" % "\n".join(lines)
+
         np_array = numpy.asarray(self.tiff_figure)
         red = np_array[::, ::, 0]
         green = np_array[::, ::, 1]


### PR DESCRIPTION
This improves the description of OMERO images created from figure export.
The image description now include references to the images that are contained in the figure (same as the PDF info page does for other forms of figure export).
This helps keep track of where an image-of-a-figure comes from.

To test:
 - export a Figure to OMERO Image
 - check the description for listing the images in the figure
 - In Insight, the ```Image ID: 123``` should be rendered as a clickable link.