### PR TITLE
Remove id from image link description

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2221,7 +2221,7 @@ class OmeroExport(TiffExport):
             if iid in img_ids:
                 continue    # ignore images we've already handled
             img_ids.add(iid)
-            lines.append('- Image ID: %s %s' % (iid, p['name']))
+            lines.append('- Image: %s %s' % (iid, p['name']))
         description += "Contains images:\n%s" % "\n".join(lines)
 
         np_array = numpy.asarray(self.tiff_figure)

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2221,7 +2221,7 @@ class OmeroExport(TiffExport):
             if iid in img_ids:
                 continue    # ignore images we've already handled
             img_ids.add(iid)
-            lines.append('- Image: %s %s' % (iid, p['name']))
+            lines.append('- Image:%s %s' % (iid, p['name']))
         description += "Contains images:\n%s" % "\n".join(lines)
 
         np_array = numpy.asarray(self.tiff_figure)


### PR DESCRIPTION
This uses "Image:123" instead of "Image ID: 123" in the description of images created from figures.
As suggested (and supported) in https://github.com/ome/openmicroscopy/pull/6087#issuecomment-517166063

NB: That PR is not merged just now, so links aren't rendered, but layout looks cleaner:

![Screen Shot 2019-08-30 at 11 17 41](https://user-images.githubusercontent.com/900055/64013714-58253d80-cb18-11e9-8880-d51082fa0151.png)
