### PR TITLE
Stroke width paste rect fix

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -323,7 +323,7 @@ class ShapeToPdfExport(ShapeExport):
         g = float(rgb[1])/255
         b = float(rgb[2])/255
         self.canvas.setStrokeColorRGB(r, g, b)
-        stroke_width = shape['strokeWidth']
+        stroke_width = shape.get('strokeWidth', 1)
         self.canvas.setLineWidth(stroke_width)
 
         p = self.canvas.beginPath()
@@ -340,7 +340,7 @@ class ShapeToPdfExport(ShapeExport):
         y1 = self.page_height - start['y']
         x2 = end['x']
         y2 = self.page_height - end['y']
-        stroke_width = shape['strokeWidth']
+        stroke_width = shape.get('strokeWidth', 1)
         # Don't draw if both points outside panel
         if (start['inPanel'] is False) and (end['inPanel'] is False):
             return
@@ -408,7 +408,7 @@ class ShapeToPdfExport(ShapeExport):
         if not polygon_in_viewport:
             return
 
-        stroke_width = shape['strokeWidth']
+        stroke_width = shape.get('strokeWidth', 1)
         r, g, b, a = self.get_rgba(shape['strokeColor'])
         self.canvas.setStrokeColorRGB(r, g, b, alpha=a)
         self.canvas.setLineWidth(stroke_width)
@@ -439,7 +439,7 @@ class ShapeToPdfExport(ShapeExport):
         self.draw_polygon(shape, False)
 
     def draw_ellipse(self, shape):
-        stroke_width = shape['strokeWidth']
+        stroke_width = shape.get('strokeWidth', 1)
         c = self.panel_to_page_coords(shape['x'], shape['y'])
 
         # Don't draw if centre outside panel
@@ -570,7 +570,7 @@ class ShapeToPilExport(ShapeExport):
         y1 = start['y']
         x2 = end['x']
         y2 = end['y']
-        head_size = ((shape['strokeWidth'] * 4) + 5)
+        head_size = ((shape.get('strokeWidth', 1) * 4) + 5)
         head_size = scale_to_export_dpi(head_size)
         stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
         rgb = ShapeToPdfExport.get_rgb(shape['strokeColor'])
@@ -837,7 +837,6 @@ class FigureExport(object):
                             stroke_width = 0.5
                         else:
                             stroke_width = 0.25
-                        print 'strokewidth', shape['strokeWidth'], stroke_width
                         shape['strokeWidth'] = stroke_width
         return figure_json
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -1,7 +1,7 @@
     
     // Version of the json file we're saving.
     // This only needs to increment when we make breaking changes (not linked to release versions.)
-    var VERSION = 3;
+    var VERSION = 4;
 
 
     // ------------------------- Figure Model -----------------------------------
@@ -162,6 +162,22 @@
                                 strokeWidth = 0.25;
                             }
                             shape.strokeWidth = strokeWidth;
+                            return shape;
+                        });
+                    }
+                });
+            }
+
+            if (v < 4) {
+                console.log("Transforming to VERSION 4");
+                _.each(json.panels, function(p){
+                    // rename lineWidth to strokeWidth
+                    if (p.shapes && p.shapes.length > 0) {
+                        p.shapes = p.shapes.map(function(shape){
+                            shape.strokeWidth = shape.strokeWidth || shape.lineWidth || 1;
+                            if (shape.lineWidth) {
+                                delete shape.lineWidth;
+                            }
                             return shape;
                         });
                     }

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -146,7 +146,7 @@
                             width: rect.width,
                             height: rect.height,
                             strokeColor: "#" + color,
-                            lineWidth: width}];
+                            strokeWidth: width}];
             } else {
                 return;
             }


### PR DESCRIPTION
See https://github.com/ome/omero-figure/issues/341

Fixes Figure export with Rectangles created from copy of crop region and paste to create Rectangle.
Previously shapes were created with "lineWidth" attribute instead of "strokeWidth".
This is fixed, and we also update previously created files when they are opened.
Workflow described in https://forum.image.sc/t/tips-tricks-gifs-from-uca-embrc-france-omero-database/32268

To test:
 - Copy crop region from one panel
 - Paste it as a new ROI on another panel (creates a Rectangle ROI)
 - Export figure