### PR TITLE
Fix page count

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -18,7 +18,6 @@
 
 import logging
 import json
-import unicodedata
 import numpy
 import cgi
 
@@ -105,8 +104,6 @@ def compress(target, base):
                         "folder.zip"
     @param base:        Name of folder that we want to zip up E.g. "folder"
     """
-    target = unicodedata.normalize('NFKD', target).encode('ascii', 'ignore')
-    print('compress: %s - %s' % (target, base))
     zip_file = zipfile.ZipFile(target, 'w')
     try:
         for root, dirs, files in os.walk(base):
@@ -114,7 +111,6 @@ def compress(target, base):
             for f in files:
                 fullpath = os.path.join(root, f)
                 archive_name = os.path.join(archive_root, f)
-                print('zip_file.write', fullpath, archive_name)
                 zip_file.write(fullpath, archive_name)
     finally:
         zip_file.close()
@@ -850,6 +846,7 @@ class FigureExport(object):
     def get_zip_name(self):
 
         name = self.figure_name
+        name = ''.join([i if ord(i) < 128 else '' for i in name])
         # in case we have path/to/name.pdf, just use name.pdf
         name = path.basename(name)
         # Remove commas: causes problems 'duplicate headers' in file download
@@ -871,6 +868,7 @@ class FigureExport(object):
         fext = self.get_figure_file_ext()
 
         name = self.figure_name
+        name = ''.join([i if ord(i) < 128 else '' for i in name])
         # in case we have path/to/name, just use name
         name = path.basename(name)
 
@@ -889,15 +887,11 @@ class FigureExport(object):
         if self.zip_folder_name is not None:
             full_name = os.path.join(self.zip_folder_name, full_name)
 
-        full_name = unicodedata.normalize('NFKD', full_name).encode('ascii', 'ignore')
-        print(full_name)
-        print(type(full_name))
         while(os.path.exists(full_name)):
             index += 1
             full_name = "%s_page_%02d.%s" % (name, index, fext)
             if self.zip_folder_name is not None:
                 full_name = os.path.join(self.zip_folder_name, full_name)
-            full_name = unicodedata.normalize('NFKD', full_name).encode('ascii', 'ignore')
 
         # Handy to know what the last created file is:
         self.figure_file_name = full_name
@@ -1005,7 +999,7 @@ class FigureExport(object):
             mimetype = "application/zip"
 
         file_ann = self.conn.createFileAnnfromLocalFile(
-            output_file.decode('utf-8'),
+            output_file,
             mimetype=mimetype,
             ns=ns)
 
@@ -2151,7 +2145,7 @@ class TiffExport(FigureExport):
         """
         self.figure_file_name = self.get_figure_file_name()
 
-        self.tiff_figure.save(self.figure_file_name.decode('utf-8'))
+        self.tiff_figure.save(self.figure_file_name)
 
         # Create a new blank tiffFigure for subsequent pages
         self.create_figure()

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -846,7 +846,6 @@ class FigureExport(object):
     def get_zip_name(self):
 
         name = self.figure_name
-        name = ''.join([i if ord(i) < 128 else '' for i in name])
         # in case we have path/to/name.pdf, just use name.pdf
         name = path.basename(name)
         # Remove commas: causes problems 'duplicate headers' in file download
@@ -868,7 +867,6 @@ class FigureExport(object):
         fext = self.get_figure_file_ext()
 
         name = self.figure_name
-        name = ''.join([i if ord(i) < 128 else '' for i in name])
         # in case we have path/to/name, just use name
         name = path.basename(name)
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -18,6 +18,7 @@
 
 import logging
 import json
+import unicodedata
 import numpy
 import cgi
 
@@ -104,6 +105,8 @@ def compress(target, base):
                         "folder.zip"
     @param base:        Name of folder that we want to zip up E.g. "folder"
     """
+    target = unicodedata.normalize('NFKD', target).encode('ascii', 'ignore')
+    print('compress: %s - %s' % (target, base))
     zip_file = zipfile.ZipFile(target, 'w')
     try:
         for root, dirs, files in os.walk(base):
@@ -111,6 +114,7 @@ def compress(target, base):
             for f in files:
                 fullpath = os.path.join(root, f)
                 archive_name = os.path.join(archive_root, f)
+                print('zip_file.write', fullpath, archive_name)
                 zip_file.write(fullpath, archive_name)
     finally:
         zip_file.close()
@@ -885,12 +889,15 @@ class FigureExport(object):
         if self.zip_folder_name is not None:
             full_name = os.path.join(self.zip_folder_name, full_name)
 
+        full_name = unicodedata.normalize('NFKD', full_name).encode('ascii', 'ignore')
+        print(full_name)
         print(type(full_name))
         while(os.path.exists(full_name)):
             index += 1
             full_name = "%s_page_%02d.%s" % (name, index, fext)
             if self.zip_folder_name is not None:
                 full_name = os.path.join(self.zip_folder_name, full_name)
+            full_name = unicodedata.normalize('NFKD', full_name).encode('ascii', 'ignore')
 
         # Handy to know what the last created file is:
         self.figure_file_name = full_name
@@ -915,7 +922,7 @@ class FigureExport(object):
         paper_spacing = ('paper_spacing' in self.figure_json and
                          self.figure_json['paper_spacing'] or 50)
         page_col_count = ('page_col_count' in self.figure_json and
-                          self.figure_json['page_col_count'] or 1)
+                          int(self.figure_json['page_col_count']) or 1)
 
         # Create a zip if we have multiple TIFF pages or we're exporting Images
         export_option = self.script_params['Export_Option']
@@ -998,7 +1005,7 @@ class FigureExport(object):
             mimetype = "application/zip"
 
         file_ann = self.conn.createFileAnnfromLocalFile(
-            output_file,
+            output_file.decode('utf-8'),
             mimetype=mimetype,
             ns=ns)
 
@@ -2144,7 +2151,7 @@ class TiffExport(FigureExport):
         """
         self.figure_file_name = self.get_figure_file_name()
 
-        self.tiff_figure.save(self.figure_file_name)
+        self.tiff_figure.save(self.figure_file_name.decode('utf-8'))
 
         # Create a new blank tiffFigure for subsequent pages
         self.create_figure()


### PR DESCRIPTION
The unicode figure name issue was eventually addressed by changes to ci (see below).
The only remaining changes to this PR are a tiny bug fix.

To test unicode figure export:
 - Create a figure named with unicode characters.
 - Export as TIFF and/or PDF
 - Add a second page (File -> Page setup) and add a panel to the new page.
 - Export as TIFF (creates a zip containing a TIFF for each page).

File names should be unchanged.

Previous errors:
```
AttributeError: 'bytes' object has no attribute 'write'
```

<details><summary>show full error</summary>

```
Traceback (most recent call last):
  File "./script", line 118, in compress
    zip_file.write(fullpath, archive_name)
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 1622, in write
    with open(filename, "rb") as src, self.open(zinfo, 'w') as dest:
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 1355, in open
    return self._open_to_write(zinfo, force_zip64=force_zip64)
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 1468, in _open_to_write
    self.fp.write(zinfo.FileHeader(zip64))
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 723, in write
    n = self.fp.write(data)
AttributeError: 'bytes' object has no attribute 'write'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./script", line 2333, in <module>
    run_script()
  File "./script", line 2319, in run_script
    file_annotation = export_figure(conn, script_params)
  File "./script", line 2275, in export_figure
    return fig_export.build_figure()
  File "./script", line 991, in build_figure
    return self.create_file_annotation(image_ids)
  File "./script", line 1001, in create_file_annotation
    compress(zip_name, self.zip_folder_name)
  File "./script", line 120, in compress
    zip_file.close()
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 1681, in close
    self._write_end_record()
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 1784, in _write_end_record
    self.fp.write(endrec)
  File "/opt/rh/rh-python36/root/lib64/python3.6/zipfile.py", line 723, in write
    n = self.fp.write(data)
AttributeError: 'bytes' object has no attribute 'write'
```
</details>

Without the line:
```
target = unicodedata.normalize('NFKD', target).encode('ascii', 'ignore')
```
I now get:
```
UnicodeEncodeError: 'ascii' codec can't encode character '\xb5' in position 10: ordinal not in range(128)
```

<details><summary>show full error</summary>

```
Traceback (most recent call last):
  File "./script", line 2333, in <module>
    run_script()
  File "./script", line 2319, in run_script
    file_annotation = export_figure(conn, script_params)
  File "./script", line 2275, in export_figure
    return fig_export.build_figure()
  File "./script", line 991, in build_figure
    return self.create_file_annotation(image_ids)
  File "./script", line 1001, in create_file_annotation
    compress(zip_name, self.zip_folder_name)
  File "./script", line 109, in compress
    print('compress: %s - %s' % (target, base))
UnicodeEncodeError: 'ascii' codec can't encode character '\xb5' in position 10: ordinal not in range(128)
```
</details>
