### PR TITLE
README says pip install reportlab and markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,13 +33,13 @@ Add figure custom app to your installed web apps:
 
 ::
 
-    $ bin/omero config append omero.web.apps '"omero_figure"'
+    $ omero config append omero.web.apps '"omero_figure"'
 
 Display a link to 'Figure' at the top of the webclient:
 
 ::
 
-    $ bin/omero config append omero.web.ui.top_links '["Figure", "figure_index",
+    $ omero config append omero.web.ui.top_links '["Figure", "figure_index",
       {"title": "Open Figure in new tab", "target": "_blank"}]' 
 
 
@@ -48,7 +48,7 @@ the webclient tree:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["omero_figure", "new_figure",
+    $ omero config append omero.web.open_with '["omero_figure", "new_figure",
       {"supported_objects":["images"], "target": "_blank", "label": "OMERO.figure"}]'
 
 Now restart OMERO.web as normal.
@@ -76,7 +76,7 @@ The command will display the absolute path to the directory where the applicatio
 ::
 
     $ cd omero_figure/scripts
-    $ path/to/OMERO.server/bin/omero script upload omero/figure_scripts/Figure_To_Pdf.py --official
+    $ omero script upload omero/figure_scripts/Figure_To_Pdf.py --official
 
 *Option 2*: Alternatively, before starting the OMERO.server, copy the script from the figure install
 ``/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py`` to the OMERO.server ``path/to/OMERO.server/lib/scripts/omero/figure_scripts``. Then restart the OMERO.server.

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ To find where OMERO.figure has been installed using pip, run:
 
 The command will display the absolute path to the directory where the application is installed e.g. ``~/<virtualenv_name>/lib/python3.6/site-packages``. Go to that directory.
 
-*Option 1*: Connect to the OMERO server and upload script via the CLI. It is important to be in the correct directory when uploading so that the script is uploaded with the full path: ``omero/figure_scripts/Figure_To_Pdf.py``:
+*Option 1*: Connect to the OMERO server and upload the script via the CLI. It is important to be in the correct directory when uploading so that the script is uploaded with the full path: ``omero/figure_scripts/Figure_To_Pdf.py``:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ The command will display the absolute path to the directory where the applicatio
 Now install the script's dependencies:
 
 
-* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package from distribution packages.
+* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package.
   This needs to be installed in the virtual environment where the server is run.
 
 ::

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,8 @@ Enabling figure export
 
 This section assumes that an OMERO.server is already installed.
 
-Figures can be exported as PDF or TIFF files using a script that runs on the OMERO.server. This script needs to be uploaded to the OMERO.server and its dependencies installed on the OMERO.server machine.
+Figures can be exported as PDF or TIFF files using a script that runs on the OMERO.server. This script needs to be uploaded to the OMERO.server and its dependencies
+installed in the OMERO.server virtual environment.
 
 The script can be uploaded using two alternative workflows, both of which require you to have the correct admin privileges.
 To find where OMERO.figure has been installed using pip, run:
@@ -68,7 +69,7 @@ To find where OMERO.figure has been installed using pip, run:
 
     $ pip show omero-figure
 
-The command will display the absolute path to the directory where the application is installed e.g. ``~/<virtualenv_name>/lib/python2.7/site-packages``. Go to that directory. 
+The command will display the absolute path to the directory where the application is installed e.g. ``~/<virtualenv_name>/lib/python3.6/site-packages``. Go to that directory.
 
 *Option 1*: Connect to the OMERO server and upload script via the CLI. It is important to be in the correct directory when uploading so that the script is uploaded with the full path: ``omero/figure_scripts/Figure_To_Pdf.py``:
 
@@ -83,17 +84,18 @@ The command will display the absolute path to the directory where the applicatio
 Now install the script's dependencies:
 
 
-* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package from distribution packages. For example, install on CentOS 7:
+* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package from distribution packages.
+  This needs to be installed in the virtual environment where the server is run.
 
 ::
 
-    $ yum install python-reportlab
+    $ pip install reportlab
 
-* Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_. For example, install on CentOS 7:
+* Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
 
 ::
 
-    $ yum install python-markdown
+    $ pip install markdown
 
 Upgrading OMERO.figure
 ----------------------


### PR DESCRIPTION
See https://forum.image.sc/t/omero-python-3-5-6-milestone-for-upgrade-testing/32120/5
and https://github.com/ome/omero-figure/pull/343/commits/de4baa608635793647f6962c6936eb92a6fe45bc

Previously we could install ```reportlab``` on CentOS with ```yum install python-reportlab``` but that doesn't target the virtualenv that we now use with py3.

See README "staged" at https://github.com/will-moore/figure/tree/pip_install_markdown_README