### PR TITLE
Public user open files

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -49,6 +49,7 @@
         WEBINDEX_URL = "{% url 'webindex' %}",
         ROIS_JSON_URL = "{% url 'api_rois' '0' %}",
         USER_FULL_NAME = "{{ userFullName }}",
+        IS_PUBLIC_USER = {% if isPublicUser %}true{% else %}false{% endif %},
         // Images larger than this are 'big' tiled images
         MAX_PLANE_SIZE = "{{ maxPlaneSize }}";
 

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     # index 'home page' of the figure app
     url(r'^$', views.index, name='figure_index'),
     url(r'^new/$', views.index, name='new_figure'),
+    url(r'^open/$', views.index, name='open_figure'),
     url(r'^file/(?P<file_id>[0-9]+)/$', views.index, name='load_figure'),
 
     url(r'^imgData/(?P<image_id>[0-9]+)/$', views.img_data_json,

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -67,7 +67,7 @@ def index(request, file_id=None, conn=None, **kwargs):
     max_plane_size = max_w * max_h
     is_public_user = False
     if (hasattr(settings, 'PUBLIC_USER')
-        and settings.PUBLIC_USER == user.getOmeName()):
+            and settings.PUBLIC_USER == user.getOmeName()):
         is_public_user = True
 
     context = {'scriptMissing': script_missing,

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -17,6 +17,7 @@
 #
 
 from django.http import Http404, HttpResponse
+from django.conf import settings
 from django.shortcuts import render
 from datetime import datetime
 import json
@@ -64,10 +65,15 @@ def index(request, file_id=None, conn=None, **kwargs):
     user_full_name = "%s %s" % (user.firstName, user.lastName)
     max_w, max_h = conn.getMaxPlaneSize()
     max_plane_size = max_w * max_h
+    is_public_user = False
+    if (hasattr(settings, 'PUBLIC_USER')
+        and settings.PUBLIC_USER == user.getOmeName()):
+        is_public_user = True
 
     context = {'scriptMissing': script_missing,
                'userFullName': user_full_name,
                'maxPlaneSize': max_plane_size,
+               'isPublicUser': is_public_user,
                'version': utils.__version__}
     return render(request, "figure/index.html", context)
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -66,6 +66,7 @@ $(function(){
         routes: {
             "": "index",
             "new(/)": "newFigure",
+            "open(/)": "openFigure",
             "file/:id(/)": "loadFigure",
         },
 
@@ -116,6 +117,14 @@ $(function(){
             $(".modal").modal('hide'); // hide any existing dialogs
             var cb = function() {
                 $('#welcomeModal').modal();
+            };
+            this.checkSaveAndClear(cb);
+        },
+
+        openFigure: function() {
+            $(".modal").modal('hide'); // hide any existing dialogs
+            var cb = function() {
+                $("#openFigureModal").modal();
             };
             this.checkSaveAndClear(cb);
         },

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -105,6 +105,9 @@ var FileListView = Backbone.View.extend({
         this.$tbody = $('tbody', this.$el);
         this.$fileFilter = $('#file-filter');
         this.owner = USER_FULL_NAME;
+        if (window.IS_PUBLIC_USER) {
+            delete this.owner;
+        }
         var self = this;
         // we automatically 'sort' on fetch, add etc.
         this.model.bind("sync remove sort", this.render, this);


### PR DESCRIPTION
Fixes #361 

This allows Public user to see all files when in Figure File > Open instead of filtering to show only the files that you own (default behaviour).

This also adds a /figure/open/ URL so you can go directly to the File > Open dialog (in the same way that /figure/new/ takes you to the Add Images dialog.

To test:
 - Enable public user
 - Go to /figure/open/
 - Should see the File > Open dialog already open, listing Files belonging to all users (not filtering for those belonging to public user).
 - Clicking on a File should open it and update the URL accordingly

cc @manics 