### PR TITLE
fix channel label mismatch

### DIFF
--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -244,7 +244,7 @@ var ChannelSliderView = Backbone.View.extend({
                 var max = maxs.reduce(reduceFn(Math.max));
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
                 // allEqualFn for booleans will return undefined if not or equal
-                var label = labels.reduce(allEqualFn, labels[0]);
+                var label = labels.reduce(allEqualFn, labels[0]) ? labels[0] : ' ';
                 var reverse = reverses.reduce(allEqualFn, reverses[0]) ? true : false;
                 var active = actives.reduce(allEqualFn, actives[0]);
                 var style = {'background-position': '0 0'}


### PR DESCRIPTION
If multiple images with same number of channels are selected, the channel buttons previously showed "undefined" if the labels didn't match.
Now we show no text.

Fixes #364.

Before:
<img width="202" alt="Screenshot 2020-04-18 at 06 51 42" src="https://user-images.githubusercontent.com/900055/79629407-64aae480-8141-11ea-990e-2904f5fdf204.png">

After:
<img width="211" alt="Screenshot 2020-04-18 at 06 51 09" src="https://user-images.githubusercontent.com/900055/79629409-6c6a8900-8141-11ea-8b1e-20ca47a0cad3.png">
