### PR TITLE
Timestamp format millisecs

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1089,17 +1089,23 @@ class FigureExport(object):
     def get_time_label_text(self, delta_t, format):
         """ Gets the text for 'live' time-stamp labels """
         # format of "secs" by default
-        text = "%s secs" % delta_t
-        if format == "mins":
-            text = "%s mins" % int(round(float(delta_t) / 60))
+        text = "%d secs" % int(round(delta_t))
+        if format == "millisecs":
+            text = "%s ms" % int(round(delta_t * 1000))
+        elif format == "mins":
+            text = "%s mins" % int(round(delta_t / 60))
+        elif format == "mins:secs":
+            m = int(delta_t // 60)
+            s = round(delta_t % 60)
+            text = "%s:%02d" % (m, s)
         elif format == "hrs:mins":
-            h = (delta_t / 3600)
-            m = int(round((float(delta_t) % 3600) / 60))
+            h = int(delta_t // 3600)
+            m = int(round((delta_t % 3600) / 60))
             text = "%s:%02d" % (h, m)
         elif format == "hrs:mins:secs":
-            h = (delta_t / 3600)
-            m = (delta_t % 3600) / 60
-            s = delta_t % 60
+            h = int(delta_t // 3600)
+            m = (delta_t % 3600) // 60
+            s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
         return text
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1089,8 +1089,8 @@ class FigureExport(object):
     def get_time_label_text(self, delta_t, format):
         """ Gets the text for 'live' time-stamp labels """
         # format of "secs" by default
-        text = "%d secs" % int(round(delta_t))
-        if format == "millisecs":
+        text = "%d s" % int(round(delta_t))
+        if format == "milliseconds":
             text = "%s ms" % int(round(delta_t * 1000))
         elif format == "mins":
             text = "%s mins" % int(round(delta_t / 60))

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright (c) 2014 University of Dundee.
+# Copyright (c) 2014-2020 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -68,6 +68,9 @@ urlpatterns = [
         '(?P<to_unit>[A-Z]+)/$',
         views.unit_conversion, name='unit_conversion'),
 
+    # Get timestamps in seconds for images
+    # Use query ?image=1&image=2
+    url(r'^timestamps/$', views.timestamps, name='figure_timestamps'),
 
     url(r'^roiCount/(?P<image_id>[0-9]+)/$', views.roi_count,
         name='figure_roiCount'),

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -210,6 +210,7 @@
                     tsUrl += '?image=' + iids.join('&image=');
                     $.getJSON(tsUrl, function(data){
                         // Update all panels
+                        // NB: By the time that this callback runs, the panels will have been created
                         self.panels.forEach(function(p){
                             var iid = p.get('imageId');
                             if (data[iid] && data[iid].length > 0) {

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -101,6 +101,7 @@
         // and transform it to latest version
         version_transform: function(json) {
             var v = json.version || 0;
+            var self = this;
 
             // In version 1, we have pixel_size_x and y.
             // Earlier versions only have pixel_size.
@@ -194,6 +195,29 @@
                         p.scalebar.units = units;
                     }
                 });
+
+                // Re-load timestamp info with no rounding (previous versions rounded to secs)
+                // Find IDs of images with deltaT
+                var iids = [];
+                _.each(json.panels, function(p){
+                    if (p.deltaT && iids.indexOf(p.imageId) == -1) {
+                        iids.push(p.imageId)
+                    }
+                });
+                console.log('Load timestamps for images', iids);
+                if (iids.length > 0) {
+                    var tsUrl = BASE_WEBFIGURE_URL + 'timestamps/';
+                    tsUrl += '?image=' + iids.join('&image=');
+                    $.getJSON(tsUrl, function(data){
+                        // Update all panels
+                        self.panels.forEach(function(p){
+                            var iid = p.get('imageId');
+                            if (data[iid] && data[iid].length > 0) {
+                                p.set('deltaT', data[iid]);
+                            }
+                        });
+                    });
+                }
             }
 
             return json;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -279,18 +279,24 @@
                 text = "", h, m, s;
             if (format === "index") {
                 text = "" + (theT + 1);
+            } else if (format === "millisecs") {
+                text = Math.round(deltaT*1000) + " ms";
             } else if (format === "secs") {
-                text = deltaT + " secs";
+                text = Math.round(deltaT) + " secs";
+            } else if (format === "mins:secs") {
+                m = parseInt(deltaT / 60);
+                s = pad(Math.round(deltaT % 60));
+                text = m + ":" + s;
             } else if (format === "mins") {
                 text = Math.round(deltaT / 60) + " mins";
             } else if (format === "hrs:mins") {
-                h = (deltaT / 3600) >> 0;
+                h = parseInt(deltaT / 3600);
                 m = pad(Math.round((deltaT % 3600) / 60));
                 text = h + ":" + m;
             } else if (format === "hrs:mins:secs") {
-                h = (deltaT / 3600) >> 0;
-                m = pad(((deltaT % 3600) / 60) >> 0);
-                s = pad(deltaT % 60);
+                h = parseInt(deltaT / 3600);
+                m = pad(parseInt((deltaT % 3600) / 60));
+                s = pad(Math.round(deltaT % 60));
                 text = h + ":" + m + ":" + s;
             }
             return text;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -313,7 +313,7 @@
         },
 
         get_label_key: function(label) {
-            var key = label.text + '_' + label.size + '_' + label.color + '_' + label.position;
+            var key = (label.text || label.time) + '_' + label.size + '_' + label.color + '_' + label.position;
             key = _.escape(key);
             return key;
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -282,7 +282,7 @@
             } else if (format === "milliseconds") {
                 text = Math.round(deltaT*1000) + " ms";
             } else if (format === "secs") {
-                text = Math.round(deltaT) + " secs";
+                text = Math.round(deltaT) + " s";
             } else if (format === "mins:secs") {
                 m = parseInt(deltaT / 60);
                 s = pad(Math.round(deltaT % 60));

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -279,7 +279,7 @@
                 text = "", h, m, s;
             if (format === "index") {
                 text = "" + (theT + 1);
-            } else if (format === "millisecs") {
+            } else if (format === "milliseconds") {
                 text = Math.round(deltaT*1000) + " ms";
             } else if (format === "secs") {
                 text = Math.round(deltaT) + " secs";

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -786,22 +786,18 @@
 
         formatTime: function(seconds) {
 
-            var mins, secs, hours;
             if (typeof seconds === 'undefined') {
                 return "";
             }
-            else if (seconds < 60) {
-                return seconds.toFixed(2) + " secs";
-            } else if (seconds < 3600) {
-                mins = (seconds / 60) >> 0;
-                secs = (seconds % 60) >> 0;
-                return mins + "min " + secs + "s";
-            } else {
-                hours = (seconds / 3600) >> 0;
-                mins = (seconds % 3600 / 60) >> 0;
-                secs = (seconds % 60) >> 0;
-                return hours + "h " + mins + "min " + secs + "s";
+            function leftPad(s) {
+                s = s + '';
+                if (s.split('.')[0].length === 1) return '0' + s;
+                return s;
             }
+            var hours = parseInt(seconds / 3600);
+            var mins = parseInt(seconds % 3600 / 60);
+            var secs = (seconds % 60).toFixed(2);
+            return leftPad(hours) + ":" + leftPad(mins) + ":" + leftPad(secs);
         },
 
         get_imgs_css: function() {

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -791,7 +791,7 @@
                 return "";
             }
             else if (seconds < 60) {
-                return seconds + " secs";
+                return seconds.toFixed(2) + " secs";
             } else if (seconds < 3600) {
                 mins = (seconds / 60) >> 0;
                 secs = (seconds % 60) >> 0;

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -26,7 +26,7 @@
                         <a href="#" data-label="[time-index]">Time (T-index)</a>
                     </li>
                     <li class="add_time_label" title="Label shows time in milliseconds">
-                        <a href="#" data-label="[time-millisecs]">Time (milli secs)</a>
+                        <a href="#" data-label="[time-millisecs]">Time (millisecs)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-secs]">Time (secs)</a>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -26,7 +26,7 @@
                         <a href="#" data-label="[time-index]">Time (T-index)</a>
                     </li>
                     <li class="add_time_label" title="Label shows time in milliseconds">
-                        <a href="#" data-label="[time-millisecs]">Time (millisecs)</a>
+                        <a href="#" data-label="[time-milliseconds]">Time (milliseconds)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-secs]">Time (secs)</a>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -23,13 +23,19 @@
                         <a href="#" data-label="[key-values]">Key-Value Pairs</a>
                     </li>
                     <li title="Add a label that shows the current T-index">
-                        <a href="#" data-label="[time-index]">Time (index)</a>
+                        <a href="#" data-label="[time-index]">Time (T-index)</a>
+                    </li>
+                    <li class="add_time_label" title="Label shows time in milliseconds">
+                        <a href="#" data-label="[time-millisecs]">Time (milli secs)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-secs]">Time (secs)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-mins]">Time (mins)</a>
+                    </li>
+                    <li class="add_time_label" title="Label shows time in mins:secs">
+                        <a href="#" data-label="[time-mins:secs]">Time (mins:secs)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-hrs:mins:secs]">Time (hrs:mins:secs)</a>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -29,7 +29,7 @@
                         <a href="#" data-label="[time-milliseconds]">Time (milliseconds)</a>
                     </li>
                     <li class="add_time_label">
-                        <a href="#" data-label="[time-secs]">Time (secs)</a>
+                        <a href="#" data-label="[time-secs]">Time (seconds)</a>
                     </li>
                     <li class="add_time_label">
                         <a href="#" data-label="[time-mins]">Time (mins)</a>


### PR DESCRIPTION
Fixes #375 

This adds supports for displaying timestamp labels in milliseconds or mins:secs.
Previously, all timestamps were loaded as *seconds* (timestamps were rounded when images were added to figures) and these integer values are stored in the figure JSON, so all existing figures can't have timestamps in milliseconds.

So, when older figures are open (VERSION 4) we now load un-rounded timestamps from the server to update those values in the figure JSON.
This allows us to choose "milliseconds" for timestamp labels (also "mins:secs") AND fixes the display of milliseconds for the label beside the T-slider.

To test:
 - Use https://merge-ci.openmicroscopy.org/web/figure/file/25179 (user-3) which was created with VERSION 4 (last release). In this figure, timestamps are rounded to seconds (integers).
 - Open this figure - Browser console will say "Transforming to VERSION 5" and "Load timestamps for images (3) [83221, 64166, 122915]".
 - Now timestamps should be available without rounding. Can see full values with File > Export as JSON.
 - Add new images - their timestamps should also not be rounded.
 - T-slider label should now show time as hh:mm:ss.ss e.g. `00:03:45.02`.
 - Add Time-labels, test using "milliseconds" and "mins:secs".
 - Save, reload. Check OK.
 - Export and check that all timestamps in PDF/TIFF match those in the web.