### PR TITLE
Ignore hidden scalebars

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1742,8 +1742,8 @@ class FigureExport(object):
         for p in panels_json:
             iid = p['imageId']
             # list unique scalebar lengths
-            if 'scalebar' in p:
-                sb_length = p['scalebar']['length']
+            if 'scalebar' in p and p['scalebar'].get('show'):
+                sb_length = p['scalebar'].get('length')
                 symbol = u"\u00B5m"
                 if 'pixel_size_x_symbol' in p:
                     symbol = p['pixel_size_x_symbol']


### PR DESCRIPTION
This fixes a minor bug, brought to light by an error from user at #379.
The error was a KeyError because 'length' was missing from the scalebar dict (don't know why). The error came from the "Info-page" code, where we add scalebars to the the info page, and I noticed that this code was not taking the visibility of the scalebar into account.

Now, we ignore the hidden scalebars on the info page AND access length with ```scalebar.get('length') to avoid KeyError.
Fixes #379 

To test:
 - Add scalebars of different lengths to 2 different panels
 - Hide 1 of the scalebars and export the PDF
 - The hidden scalebar should be ignored in the "Scalebar lenghts" of the page-info 
