### PR TITLE
Fix negative timestamps format

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1089,6 +1089,8 @@ class FigureExport(object):
     def get_time_label_text(self, delta_t, format):
         """ Gets the text for 'live' time-stamp labels """
         # format of "secs" by default
+        isNegative = delta_t < 0
+        delta_t = abs(delta_t)
         text = "%d s" % int(round(delta_t))
         if format == "milliseconds":
             text = "%s ms" % int(round(delta_t * 1000))
@@ -1107,7 +1109,7 @@ class FigureExport(object):
             m = (delta_t % 3600) // 60
             s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
-        return text
+        return ('-' if isNegative else '') + text
 
     def add_rois(self, panel, page):
         """

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1109,6 +1109,8 @@ class FigureExport(object):
             m = (delta_t % 3600) // 60
             s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
+        if text in ["0 s", "0:00", "0 mins", "0:00:00"]:
+            is_negative = False
         return ('-' if is_negative else '') + text
 
     def add_rois(self, panel, page):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1089,7 +1089,7 @@ class FigureExport(object):
     def get_time_label_text(self, delta_t, format):
         """ Gets the text for 'live' time-stamp labels """
         # format of "secs" by default
-        isNegative = delta_t < 0
+        is_negative = delta_t < 0
         delta_t = abs(delta_t)
         text = "%d s" % int(round(delta_t))
         if format == "milliseconds":
@@ -1109,7 +1109,7 @@ class FigureExport(object):
             m = (delta_t % 3600) // 60
             s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
-        return ('-' if isNegative else '') + text
+        return ('-' if is_negative else '') + text
 
     def add_rois(self, panel, page):
         """

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -280,6 +280,7 @@
                 text = "", h, m, s;
             deltaT = Math.abs(deltaT);
             if (format === "index") {
+                isNegative = false;
                 text = "" + (theT + 1);
             } else if (format === "milliseconds") {
                 text = Math.round(deltaT*1000) + " ms";

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -276,7 +276,9 @@
             };
             var theT = this.get('theT'),
                 deltaT = this.get('deltaT')[theT] || 0,
+                isNegative = (deltaT < 0),
                 text = "", h, m, s;
+            deltaT = Math.abs(deltaT);
             if (format === "index") {
                 text = "" + (theT + 1);
             } else if (format === "milliseconds") {
@@ -299,7 +301,7 @@
                 s = pad(Math.round(deltaT % 60));
                 text = h + ":" + m + ":" + s;
             }
-            return text;
+            return (isNegative ? '-' : '') + text;
         },
 
         create_labels_from_time: function(options) {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -302,6 +302,9 @@
                 s = pad(Math.round(deltaT % 60));
                 text = h + ":" + m + ":" + s;
             }
+            if (["0 s", "0:00", "0 mins", "0:00:00"].indexOf(text) > -1) {
+                isNegative = false;
+            }
             return (isNegative ? '-' : '') + text;
         },
 

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -789,7 +789,7 @@
             if (typeof seconds === 'undefined') {
                 return "";
             }
-            var isNegative = seconds < 1;
+            var isNegative = seconds < 0;
             seconds = Math.abs(seconds);
             function leftPad(s) {
                 s = s + '';

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -789,6 +789,8 @@
             if (typeof seconds === 'undefined') {
                 return "";
             }
+            var isNegative = seconds < 1;
+            seconds = Math.abs(seconds);
             function leftPad(s) {
                 s = s + '';
                 if (s.split('.')[0].length === 1) return '0' + s;
@@ -797,7 +799,7 @@
             var hours = parseInt(seconds / 3600);
             var mins = parseInt(seconds % 3600 / 60);
             var secs = (seconds % 60).toFixed(2);
-            return leftPad(hours) + ":" + leftPad(mins) + ":" + leftPad(secs);
+            return (isNegative ? '-' : '') + leftPad(hours) + ":" + leftPad(mins) + ":" + leftPad(secs);
         },
 
         get_imgs_css: function() {


### PR DESCRIPTION
Noticed bug with negative timestamps using hh:mm:ss format or mm:ss format since we round the hrs and minutes *down* in the UI and export script.

To test, check that the timestamps are shown correctly on this figure (screenshot shows current bug) e.g. ```0:00:-1``` and ```-1:59:59```

<img width="617" alt="Screenshot 2020-05-11 at 00 04 15" src="https://user-images.githubusercontent.com/900055/81512815-59e80780-931b-11ea-9598-e1e8909795f3.png">
