### PR TITLE
break utils.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-
 4.3.0 (May 2020)
 ----------------
 
-- Add support for time-stamps in milliseconds([#378](https://github.com/ome/omero-figure/pull/378))
+- Add support for time-stamps in milliseconds ([#378](https://github.com/ome/omero-figure/pull/378))
 - Show other users' files to Public user ([#362](https://github.com/ome/omero-figure/pull/362))
 - Fix saving of Figures with no panels ([#363](https://github.com/ome/omero-figure/pull/363))
 - Fix enable of Save when nudge panels ([#376](https://github.com/ome/omero-figure/pull/376))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 4.3.0 (May 2020)
 ----------------
 
-- Add support for time-stamps in milliseconds ([#378](https://github.com/ome/omero-figure/pull/378))
+- Add support for timestamps in milliseconds ([#378](https://github.com/ome/omero-figure/pull/378))
 - Show other users' files to Public user ([#362](https://github.com/ome/omero-figure/pull/362))
 - Fix saving of Figures with no panels ([#363](https://github.com/ome/omero-figure/pull/363))
 - Fix enable of Save when nudge panels ([#376](https://github.com/ome/omero-figure/pull/376))

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2020 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from omero.sys import ParametersI
+from omero.gateway import PlaneInfoWrapper
+
+
+def get_timestamps(conn, image):
+
+    params = ParametersI()
+    params.addLong('pid', image.getPixelsId())
+    query = "from PlaneInfo as Info where"\
+        " Info.theZ=0 and Info.theC=0 and pixels.id=:pid"
+    info_list = conn.getQueryService().findAllByQuery(
+        query, params, conn.SERVICE_OPTS)
+    timemap = {}
+    for info in info_list:
+        t_index = info.theT.getValue()
+        if info.deltaT is not None:
+            # Use wrapper to help unit conversion
+            plane_info = PlaneInfoWrapper(conn, info)
+            delta_t = plane_info.getDeltaT('SECOND')
+            timemap[t_index] = delta_t.getValue()
+    time_list = []
+    for t in range(image.getSizeT()):
+        if t in timemap:
+            time_list.append(timemap[t])
+    return time_list

--- a/omero_figure/utils.py
+++ b/omero_figure/utils.py
@@ -18,8 +18,6 @@
 
 import json
 import os
-from omero.sys import ParametersI
-from omero.gateway import PlaneInfoWrapper
 
 __version__ = "4.2.1.dev0"
 
@@ -32,26 +30,3 @@ def read_file(fname, content_type=None):
         else:
             data = f.read()
     return data
-
-
-def get_timestamps(conn, image):
-
-    params = ParametersI()
-    params.addLong('pid', image.getPixelsId())
-    query = "from PlaneInfo as Info where"\
-        " Info.theZ=0 and Info.theC=0 and pixels.id=:pid"
-    info_list = conn.getQueryService().findAllByQuery(
-        query, params, conn.SERVICE_OPTS)
-    timemap = {}
-    for info in info_list:
-        t_index = info.theT.getValue()
-        if info.deltaT is not None:
-            # Use wrapper to help unit conversion
-            plane_info = PlaneInfoWrapper(conn, info)
-            delta_t = plane_info.getDeltaT('SECOND')
-            timemap[t_index] = delta_t.getValue()
-    time_list = []
-    for t in range(image.getSizeT()):
-        if t in timemap:
-            time_list.append(timemap[t])
-    return time_list

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -36,7 +36,7 @@ import omero
 from io import BytesIO
 
 from omeroweb.webclient.decorators import login_required
-from .utils import get_timestamps
+from .omeroutils import get_timestamps
 
 from . import utils
 import logging


### PR DESCRIPTION
Re-organise code, having ``import omero`` prevents the deployment via travis
```
 File "setup.py", line 31, in <module>
    import [secure]ro_figure.utils as utils
  File "/h[secure]/travis/build/[secure]/[secure]ro-figure/[secure]ro_figure/utils.py", line 21, in <module>
    from [secure]ro.sys import ParametersI
ModuleNotFoundError: No module named '[secure]ro'
```

To test this PR:
* create a conda env with nodejs only (not omero)
* run ``python setup.py sdist``

Problem introduced in https://github.com/ome/omero-figure/pull/378
cc @will-moore 