### PR TITLE
Replace cgi.escape by html.escape.

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -20,7 +20,7 @@
 import logging
 import json
 import numpy
-import cgi
+import html
 
 from datetime import datetime
 import os
@@ -301,7 +301,7 @@ class ShapeToPdfExport(ShapeExport):
 
     def draw_shape_label(self, shape, bounds):
         center = bounds.get_center()
-        text = cgi.escape(shape.get('text', ''))
+        text = html.escape(shape.get('text', ''))
         if not text or not center:
             return
         size = shape.get('fontSize', 12) * 2 / 3


### PR DESCRIPTION
The escape function in the cgi module has been deprecated since
Python 3.2 [1] and has finally been removed in Python 3.8 [2],
resulting in the Figure_To_Pdf.py script failing to run under
Python 3.8.

This patch replaces the call to cgi.escape by html.escape, as
recommended by the Python developers.

[1] https://docs.python.org/3.7/library/cgi.html#cgi.escape
[2] https://docs.python.org/3.8/whatsnew/3.8.html#api-and-feature-removals