### PR TITLE
Draw rectangle fix

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -638,7 +638,7 @@ class ShapeToPilExport(ShapeExport):
         p.append(p[0])
         points = p
 
-        stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))
+        stroke_width = scale_to_export_dpi(int(shape.get('strokeWidth', 2)))
         buffer = int(ceil(stroke_width) * 1.5)
 
         # if fill, draw filled polygon without outline, then add line later


### PR DESCRIPTION
Not sure about the cause or how to reproduce as it's been reported to us via support channel. In some conditions it's possible to run into the following issue:

```
Traceback (most recent call last):

  File "./script", line 2361, in <module>

    run_script()

  File "./script", line 2347, in run_script

    file_annotation = export_figure(conn, script_params)

  File "./script", line 2303, in export_figure

    return fig_export.build_figure()

  File "./script", line 977, in build_figure

    self.add_panels_to_page(panels_json, image_ids, page)

  File "./script", line 1803, in add_panels_to_page

    image, pil_img = self.draw_panel(panel, page, i)

  File "./script", line 1634, in draw_panel

    self.paste_image(pil_img, img_name, panel, page, dpi)

  File "./script", line 2055, in paste_image

    ShapeToPilExport(pil_img, panel, crop)

  File "./script", line 522, in __init__

    super(ShapeToPilExport, self).__init__(panel)

  File "./script", line 187, in __init__

    getattr(self, 'draw_%s' % s['type'].lower(), lambda s: None)(s)

  File "./script", line 641, in draw_rectangle

    stroke_width = scale_to_export_dpi(shape.get('strokeWidth', 2))

  File "./script", line 111, in scale_to_export_dpi

    return pixels * 300//72

TypeError: unsupported operand type(s) for //: 'str' and 'int'
```

A fixed proposed here address it directly in the Export script. Not sure if it's possible to fix it earlier at the Figure_JSON level.

