### PR TITLE
Crop rotation fixes

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -450,6 +450,7 @@
 
         // resize, zoom and pan to show the specified region.
         // new panel will fit inside existing panel
+        // coords is {x:x, y:y, width:w, height:h, rotation?:r}
         cropToRoi: function(coords) {
             var targetWH = coords.width/coords.height,
                 currentWH = this.get('width')/this.get('height'),
@@ -473,7 +474,14 @@
                 yPercent = this.get('orig_height') / coords.height,
                 zoom = Math.min(xPercent, yPercent) * 100;
 
-            this.set({'width': newW, 'height': newH, 'dx': dx, 'dy': dy, 'zoom': zoom});
+            var toSet = { 'width': newW, 'height': newH, 'dx': dx, 'dy': dy, 'zoom': zoom };
+            if (coords.rotation) {
+                var rotation = parseInt(coords.rotation);
+                if (!isNaN(rotation)) {
+                    toSet.rotation = rotation;
+                }
+            }
+            this.save(toSet);
         },
 
         // returns the current viewport as a Rect {x, y, width, height}

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -609,10 +609,12 @@
         },
 
         // Turn coordinates into css object with rotation transform
-        _viewport_css: function(img_x, img_y, img_w, img_h, frame_w, frame_h) {
+        _viewport_css: function(img_x, img_y, img_w, img_h, frame_w, frame_h, rotation) {
             var transform_x = 100 * (frame_w/2 - img_x) / img_w,
-                transform_y = 100 * (frame_h/2 - img_y) / img_h,
+                transform_y = 100 * (frame_h/2 - img_y) / img_h;
+            if (rotation == undefined) {
                 rotation = this.get('rotation') || 0;
+            }
 
             var css = {'left':img_x,
                        'top':img_y,

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -481,6 +481,7 @@
             zoom = zoom !== undefined ? zoom : this.get('zoom');
             dx = dx !== undefined ? dx : this.get('dx');
             dy = dy !== undefined ? dy : this.get('dy');
+            var rotation = this.get('rotation');
 
             var width = this.get('width'),
                 height = this.get('height'),
@@ -497,7 +498,8 @@
                 view_wh = width / height;
             if (dx === 0 && dy === 0 && zoom == 100 && Math.abs(orig_wh - view_wh) < 0.01) {
                 // ...ROI is whole image
-                return {'x': 0, 'y': 0, 'width': orig_width, 'height': orig_height}
+                return {'x': 0, 'y': 0, 'width': orig_width,
+                    'height': orig_height, 'rotation': rotation}
             }
 
             // Factor in the applied zoom...
@@ -512,7 +514,8 @@
                 roiX = cX - (roiW / 2),
                 roiY = cY - (roiH / 2);
 
-            return {'x': roiX, 'y': roiY, 'width': roiW, 'height': roiH};
+            return {'x': roiX, 'y': roiY, 'width': roiW,
+                'height': roiH, 'rotation': rotation};
         },
 
         // Drag resizing - notify the PanelView without saving

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -475,11 +475,9 @@
                 zoom = Math.min(xPercent, yPercent) * 100;
 
             var toSet = { 'width': newW, 'height': newH, 'dx': dx, 'dy': dy, 'zoom': zoom };
-            if (coords.rotation) {
-                var rotation = parseInt(coords.rotation);
-                if (!isNaN(rotation)) {
-                    toSet.rotation = rotation;
-                }
+            var rotation = coords.rotation || 0;
+            if (!isNaN(rotation)) {
+                toSet.rotation = rotation;
             }
             this.save(toSet);
         },

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -140,8 +140,12 @@ var CropModalView = Backbone.View.extend({
                 y = parseInt($roi.attr('data-y'), 10),
                 width = parseInt($roi.attr('data-width'), 10),
                 height = parseInt($roi.attr('data-height'), 10),
+                rotation = $roi.attr('data-rotation') || 0,
                 theT = parseInt($roi.attr('data-theT'), 10),
                 theZ = parseInt($roi.attr('data-theZ'), 10);
+
+            // Rectangle ROIs have NO rotation. Copy of crop might have rotation
+            this.m.set('rotation', parseInt(rotation));
 
             this.m.set({'theT': theT, 'theZ': theZ});
 
@@ -164,8 +168,6 @@ var CropModalView = Backbone.View.extend({
             // var json = this.processForm();
             var self = this,
                 r = this.currentROI,
-                theZ = this.m.get('theZ'),
-                theT = this.m.get('theT'),
                 sel = this.model.getSelected(),
                 sameT = sel.allEqual('theT');
                 // sameZT = sel.allEqual('theT') && sel.allEqual('theT');
@@ -252,7 +254,7 @@ var CropModalView = Backbone.View.extend({
                         m.unset('shapes');
                     }
                     // 'save' to trigger 'unsaved': true
-                    m.save({'theZ': newZ, 'theT': newT});
+                    m.save({ 'theZ': newZ, 'theT': newT, 'rotation': self.m.get('rotation')});
                 });
             }
 
@@ -323,13 +325,13 @@ var CropModalView = Backbone.View.extend({
 
         showClipboardFigureRois: function() {
             // Show Rectangles from clipboard
-            var imageRects = [],
-                clipboardRects = [],
+            var clipboardRects = [],
                 clipboard = this.model.get('clipboard');
             if (clipboard && clipboard.CROP) {
                 roi = clipboard.CROP;
                 clipboardRects.push({
-                    x: roi.x, y: roi.y, width: roi.width, height: roi.height
+                    x: roi.x, y: roi.y, width: roi.width, height: roi.height,
+                    rotation: roi.rotation
                 });
             } else if (clipboard && clipboard.SHAPES) {
                 clipboard.SHAPES.forEach(function(roi){
@@ -487,6 +489,8 @@ var CropModalView = Backbone.View.extend({
                 left = -(zoom * rect.x);
                 rect.theT = rect.theT !== undefined ? rect.theT : origT;
                 rect.theZ = rect.theZ !== undefined ? rect.theZ : origZ;
+                let rotation = rect.rotation || 0;
+                let css = this.m._viewport_css(top, left, img_w, img_h, size, size, rotation);
 
                 var json = {
                     'msg': msg,
@@ -494,6 +498,7 @@ var CropModalView = Backbone.View.extend({
                     'rect': rect,
                     'w': div_w,
                     'h': div_h,
+                    'css': css,
                     'top': top,
                     'left': left,
                     'img_w': img_w,

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -8,6 +8,16 @@ var CropModalView = Backbone.View.extend({
 
         model:FigureModel,
 
+        rotatePoint: function (x, y, cx, cy, rotation) {
+            // Get coordinates for point x, y rotate around cx, cy, by rotation degrees
+            let length = Math.sqrt(Math.pow((x - cx), 2) + Math.pow((y - cy), 2));
+            let rot = Math.atan2((y - cy), (x - cx));
+            rot = rot + (rotation * (Math.PI / 180));  // degrees to rad
+            let dx = Math.cos(rot) * length;
+            let dy = Math.sin(rot) * length;
+            return { x: cx + dx, y: cy + dy };
+        },
+
         initialize: function() {
 
             var self = this;
@@ -22,6 +32,16 @@ var CropModalView = Backbone.View.extend({
 
                 // get selected area...
                 var roi = self.m.getViewportAsRect();
+                var rotation = self.m.get('rotation');
+                if (rotation != 0) {
+                    var img_cx = self.m.get('orig_width') / 2;
+                    var img_cy = self.m.get('orig_height') / 2;
+                    var rect_cx = roi.x + (roi.width / 2);
+                    var rect_cy = roi.y + (roi.height / 2);
+                    var new_c = self.rotatePoint(rect_cx, rect_cy, img_cx, img_cy, rotation);
+                    roi.x = new_c.x - (roi.width / 2);
+                    roi.y = new_c.y - (roi.height / 2);
+                }
 
                 // Show as ROI *if* it isn't the whole image
                 if (roi.x !== 0 || roi.y !== 0
@@ -167,6 +187,18 @@ var CropModalView = Backbone.View.extend({
                 if (sameT) {
                     t = self.m.get('theT');
                 }
+
+                var rotation = self.m.get('rotation');
+                if (rotation != 0) {
+                    var img_cx = self.m.get('orig_width') / 2;
+                    var img_cy = self.m.get('orig_height') / 2;
+                    var rect_cx = r.x + (r.width / 2);
+                    var rect_cy = r.y + (r.height / 2);
+                    var new_c = self.rotatePoint(rect_cx, rect_cy, img_cx, img_cy, -rotation);
+                    r.x = new_c.x - (r.width / 2);
+                    r.y = new_c.y - (r.height / 2);
+                }
+
                 var rv = {'x': r.x,
                         'y': r.y,
                         'width': r.width,

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -8,16 +8,6 @@ var CropModalView = Backbone.View.extend({
 
         model:FigureModel,
 
-        rotatePoint: function (x, y, cx, cy, rotation) {
-            // Get coordinates for point x, y rotate around cx, cy, by rotation degrees
-            let length = Math.sqrt(Math.pow((x - cx), 2) + Math.pow((y - cy), 2));
-            let rot = Math.atan2((y - cy), (x - cx));
-            rot = rot + (rotation * (Math.PI / 180));  // degrees to rad
-            let dx = Math.cos(rot) * length;
-            let dy = Math.sin(rot) * length;
-            return { x: cx + dx, y: cy + dy };
-        },
-
         initialize: function() {
 
             var self = this;
@@ -38,7 +28,7 @@ var CropModalView = Backbone.View.extend({
                     var img_cy = self.m.get('orig_height') / 2;
                     var rect_cx = roi.x + (roi.width / 2);
                     var rect_cy = roi.y + (roi.height / 2);
-                    var new_c = self.rotatePoint(rect_cx, rect_cy, img_cx, img_cy, rotation);
+                    var new_c = rotatePoint(rect_cx, rect_cy, img_cx, img_cy, rotation);
                     roi.x = new_c.x - (roi.width / 2);
                     roi.y = new_c.y - (roi.height / 2);
                 }
@@ -194,7 +184,7 @@ var CropModalView = Backbone.View.extend({
                     var img_cy = self.m.get('orig_height') / 2;
                     var rect_cx = r.x + (r.width / 2);
                     var rect_cy = r.y + (r.height / 2);
-                    var new_c = self.rotatePoint(rect_cx, rect_cy, img_cx, img_cy, -rotation);
+                    var new_c = rotatePoint(rect_cx, rect_cy, img_cx, img_cy, -rotation);
                     r.x = new_c.x - (r.width / 2);
                     r.y = new_c.y - (r.height / 2);
                 }

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -22,16 +22,7 @@ var CropModalView = Backbone.View.extend({
 
                 // get selected area...
                 var roi = self.m.getViewportAsRect();
-                var rotation = self.m.get('rotation');
-                if (rotation != 0) {
-                    var img_cx = self.m.get('orig_width') / 2;
-                    var img_cy = self.m.get('orig_height') / 2;
-                    var rect_cx = roi.x + (roi.width / 2);
-                    var rect_cy = roi.y + (roi.height / 2);
-                    var new_c = rotatePoint(rect_cx, rect_cy, img_cx, img_cy, rotation);
-                    roi.x = new_c.x - (roi.width / 2);
-                    roi.y = new_c.y - (roi.height / 2);
-                }
+                self.applyRotation(roi);
 
                 // Show as ROI *if* it isn't the whole image
                 if (roi.x !== 0 || roi.y !== 0
@@ -163,6 +154,22 @@ var CropModalView = Backbone.View.extend({
             this.currentRoiId = $roi.attr('data-roiId');
         },
 
+        applyRotation: function(rect, factor=1) {
+            // Update the x and y coordinates of a Rectangle ROI to take account of rotation of the
+            // underlying image around it's centre point. The image is rotated on the canvas, so any
+            // Rectangle not at the centre will need to be rotated around the centre, updating rect.x and rect.y.
+            var rotation = this.m.get('rotation');
+            if (rotation != 0) {
+                var img_cx = this.m.get('orig_width') / 2;
+                var img_cy = this.m.get('orig_height') / 2;
+                var rect_cx = rect.x + (rect.width / 2);
+                var rect_cy = rect.y + (rect.height / 2);
+                var new_c = rotatePoint(rect_cx, rect_cy, img_cx, img_cy, rotation * factor);
+                rect.x = new_c.x - (rect.width / 2);
+                rect.y = new_c.y - (rect.height / 2);
+            }
+        },
+
         handleRoiForm: function(event) {
             event.preventDefault();
             // var json = this.processForm();
@@ -180,16 +187,7 @@ var CropModalView = Backbone.View.extend({
                     t = self.m.get('theT');
                 }
 
-                var rotation = self.m.get('rotation');
-                if (rotation != 0) {
-                    var img_cx = self.m.get('orig_width') / 2;
-                    var img_cy = self.m.get('orig_height') / 2;
-                    var rect_cx = r.x + (r.width / 2);
-                    var rect_cy = r.y + (r.height / 2);
-                    var new_c = rotatePoint(rect_cx, rect_cy, img_cx, img_cy, -rotation);
-                    r.x = new_c.x - (r.width / 2);
-                    r.y = new_c.y - (r.height / 2);
-                }
+                self.applyRotation(r, -1);
 
                 var rv = {'x': r.x,
                         'y': r.y,

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -136,13 +136,16 @@ var CropModalView = Backbone.View.extend({
                 theZ = parseInt($roi.attr('data-theZ'), 10);
 
             // Rectangle ROIs have NO rotation. Copy of crop might have rotation
-            this.m.set('rotation', parseInt(rotation));
+            rotation = parseInt(rotation);
+            this.m.set('rotation', rotation);
 
             this.m.set({'theT': theT, 'theZ': theZ});
 
             this.currentROI = {
                 'x':x, 'y':y, 'width':width, 'height':height
             }
+            // Update coords based on any rotation (if coords come from rotated crop region)
+            this.applyRotation(this.currentROI, 1, rotation);
 
             this.render();
 
@@ -154,11 +157,13 @@ var CropModalView = Backbone.View.extend({
             this.currentRoiId = $roi.attr('data-roiId');
         },
 
-        applyRotation: function(rect, factor=1) {
+        applyRotation: function(rect, factor=1, rotation) {
             // Update the x and y coordinates of a Rectangle ROI to take account of rotation of the
             // underlying image around it's centre point. The image is rotated on the canvas, so any
             // Rectangle not at the centre will need to be rotated around the centre, updating rect.x and rect.y.
-            var rotation = this.m.get('rotation');
+            if (rotation === undefined) {
+                rotation = this.m.get('rotation');
+            }
             if (rotation != 0) {
                 var img_cx = this.m.get('orig_width') / 2;
                 var img_cy = this.m.get('orig_height') / 2;
@@ -470,6 +475,7 @@ var CropModalView = Backbone.View.extend({
 
             for (var r=0; r<rects.length; r++) {
                 rect = rects[r];
+                let rotation = rect.rotation || 0;
                 if (rect.theT > -1) this.m.set('theT', rect.theT, {'silent': true});
                 if (rect.theZ > -1) this.m.set('theZ', rect.theZ, {'silent': true});
                 src = this.m.get_img_src(true);
@@ -487,8 +493,7 @@ var CropModalView = Backbone.View.extend({
                 left = -(zoom * rect.x);
                 rect.theT = rect.theT !== undefined ? rect.theT : origT;
                 rect.theZ = rect.theZ !== undefined ? rect.theZ : origZ;
-                let rotation = rect.rotation || 0;
-                let css = this.m._viewport_css(top, left, img_w, img_h, size, size, rotation);
+                let css = this.m._viewport_css(left, top, img_w, img_h, size, size, rotation);
 
                 var json = {
                     'msg': msg,

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -124,28 +124,18 @@
             this.render();
         },
 
-        rotatePoint: function(x, y, cx, cy, rotation) {
-            // Get coordinates for point x, y rotate around cx, cy, by rotation degrees
-            let length = Math.sqrt(Math.pow((x - cx), 2) + Math.pow((y - cy), 2));
-            let rot = Math.atan2((y - cy), (x - cx));
-            rot = rot + (rotation * (Math.PI / 180));  // degrees to rad
-            let dx = Math.cos(rot) * length;
-            let dy = Math.sin(rot) * length;
-            return {x: cx + dx, y: cy + dy};
-        },
-
         rectToPolygon: function(rect, rotation) {
             // rotate Rect around centre point - return points "x,y, x,y, x,y, x,y"
             let cx = rect.x + (rect.width / 2);
             let cy = rect.y + (rect.height / 2);
             // topleft
-            let tl = this.rotatePoint(rect.x, rect.y, cx, cy, rotation);
+            let tl = rotatePoint(rect.x, rect.y, cx, cy, rotation);
             // topright
-            let tr = this.rotatePoint(rect.x + rect.width, rect.y, cx, cy, rotation);
+            let tr = rotatePoint(rect.x + rect.width, rect.y, cx, cy, rotation);
             // bottomright
-            let br = this.rotatePoint(rect.x + rect.width, rect.y + rect.height, cx, cy, rotation);
+            let br = rotatePoint(rect.x + rect.width, rect.y + rect.height, cx, cy, rotation);
             // bottomleft
-            let bl = this.rotatePoint(rect.x, rect.y + rect.height, cx, cy, rotation);
+            let bl = rotatePoint(rect.x, rect.y + rect.height, cx, cy, rotation);
             return [tl, tr, br, bl].map(point => point.x + ',' + point.y).join(', ');
         },
 

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -147,6 +147,16 @@ $.prototype.slider = function() {
 }
 
 
+// Get coordinates for point x, y rotated around cx, cy, by rotation degrees
+var rotatePoint = function (x, y, cx, cy, rotation) {
+    let length = Math.sqrt(Math.pow((x - cx), 2) + Math.pow((y - cy), 2));
+    let rot = Math.atan2((y - cy), (x - cx));
+    rot = rot + (rotation * (Math.PI / 180));  // degrees to rad
+    let dx = Math.cos(rot) * length;
+    let dy = Math.sin(rot) * length;
+    return { x: cx + dx, y: cy + dy };
+}
+
 $(function(){
 
 

--- a/src/templates/modal_dialogs/crop_modal_roi.html
+++ b/src/templates/modal_dialogs/crop_modal_roi.html
@@ -4,10 +4,14 @@
         <div class="roi_wrapper" style="position: relative; overflow: hidden; margin: 5px; height: <%= h %>px; width: <%= w %>px">
             <img class="roi_content"
                 data-roiId="<%= roiId %>"
+                data-rotation="<%= rect.rotation %>"
                 data-x="<%= rect.x %>" data-y="<%= rect.y %>" 
                 data-width="<%= rect.width %>" data-height="<%= rect.height %>"
                 data-theT="<%= rect.theT %>" data-theZ="<%= rect.theZ %>"
-                style="position: absolute; top: <%= top %>px; left: <%= left %>px; width: <%= img_w %>px; height: <%= img_h %>px" src='<%= src %>' />
+                style="position: absolute; top: <%= top %>px; left: <%= left %>px; width: <%= img_w %>px; height: <%= img_h %>px;
+                transform: <%= css.transform %>;
+                transform-origin: <%= css['transform-origin'] %>;"
+                src='<%= src %>' />
         </div>
     </td>
     <% if (zStart) { %>


### PR DESCRIPTION
Fixes #408 - copy rotated crop region and paste to ROI.
Also fixes #324

Rectangle ROIs don't support rotation, but this fixes the issue above by creating a Polygon to simulate a rotated Rectangle.

To test:
 - Copy & Paste to duplicate a panel, then zoom in to crop, and rotate one of them.
 - Copy the Crop region and Paste it as a new Shape on the un-zoomed panel - The new Shape (Polygon) should match the crop region:

<img width="479" alt="Screenshot 2020-12-08 at 21 55 42" src="https://user-images.githubusercontent.com/900055/101547901-ebe3eb80-39a2-11eb-8ad5-1ada7a84d1ae.png">

 - Copy the rotated Crop region, select the uncropped (unrotated) Panel and click Paste to paste the rotated crop region. The rotation should also be applied to the panel so that both images show the same rotated viewport.
 - Crop the rotated panel using the "Crop" button. The 'initial' crop region should match the current viewport (see screenshot) and the updated crop region should be correctly applied to the panel.

![Screenshot 2020-12-15 at 14 28 10](https://user-images.githubusercontent.com/900055/102227705-c9d9f400-3ee1-11eb-9c56-963be3620252.png)

