### PR TITLE
Fix scalebar units in PDF export

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1749,8 +1749,9 @@ class FigureExport(object):
             if 'scalebar' in p and p['scalebar'].get('show'):
                 sb_length = p['scalebar'].get('length')
                 symbol = u"\u00B5m"
-                if 'pixel_size_x_symbol' in p:
-                    symbol = p['pixel_size_x_symbol']
+                sb_units = p['scalebar'].get('units')
+                if sb_units and sb_units in unit_symbols:
+                    symbol = unit_symbols[sb_units]['symbol']
                 scalebars.append("%s %s" % (sb_length, symbol))
             if iid in img_ids:
                 continue    # ignore images we've already handled


### PR DESCRIPTION
Fixes #406 

To test:
 - Add scalebars with different units to different images
 - Export as PDF
 - Check that units are shown correctly in info page:

![Screenshot 2020-12-14 at 14 36 44](https://user-images.githubusercontent.com/900055/102094119-d8f56f00-3e19-11eb-9323-a08759db333e.png)
