### PR TITLE
scalebar show label by default

### DIFF
--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -111,7 +111,7 @@ var ScalebarFormView = Backbone.View.extend({
     },
 
     render: function() {
-        var json = {show: false, show_label: false},
+        var json = {show: false, show_label: true},
             hidden = false,
             sb;
 


### PR DESCRIPTION
The paper https://www.biorxiv.org/content/10.1101/2020.10.08.327718v1.full
mentioned in https://github.com/ome/omero-figure/issues/407
has this advice about scalebars:

Annotate scale bar dimensions on the image: Stating the dimensions along with the scale bar allows readers to interpret the image more quickly.

This PR encourages users to add the label on the scale bar by showing the label by default.

To test:
 - Add a new Image panel
 - Add a scalebar - the label should be shown by default.
 - This won't change any existing figures where scale bars have been added to image panels already (even if the scale bar has subsequently been hidden) but if it's the first time that a scale bar has been added to a panel, the default 'show label' will apply.