### PR TITLE
Avoid duplicate labels from Key-Values

### DIFF
--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -66,8 +66,10 @@ var LabelFromMapsModal = Backbone.View.extend({
                 prev[iid] = [];
             }
             t.values.forEach(function(kv) {
-                if (kv[0] === key) {
-                    prev[iid].push(kv[1]);
+                var value = kv[1];
+                // If key matches, add to values for the image (no duplicates)
+                if (kv[0] === key && prev[iid].indexOf(value) === -1) {
+                    prev[iid].push(value);
                 }
             });
             return prev;


### PR DESCRIPTION
Fixes #395

To test:
 - Add duplicate Key-Value pairs to an Image
 - Choose that Key when adding labels to the image from key-value pairs.
 - Only 1 label should be created on each Panel for the duplicate Key-Value pairs.