### PR TITLE
Handle save errors

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -47,12 +47,15 @@
         ACTIVITIES_JSON_URL = "{% url 'activities_json' %}",
         WEBGATEWAYINDEX = "{% url 'webgateway' %}",
         WEBINDEX_URL = "{% url 'webindex' %}",
+        WEBLOGIN_URL = "{% url 'weblogin' %}",
         ROIS_JSON_URL = "{% url 'api_rois' '0' %}",
         USER_FULL_NAME = "{{ userFullName }}",
         LENGTH_UNITS = {{ lengthUnits|safe }},
         IS_PUBLIC_USER = {% if isPublicUser %}true{% else %}false{% endif %},
         // Images larger than this are 'big' tiled images
         MAX_PLANE_SIZE = "{{ maxPlaneSize }}";
+
+    var LOCAL_STORAGE_RECOVERED_FIGURE = "recoveredFigure";
 
     $(document).ready(function() {
 

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -663,6 +663,9 @@
                             <li class="save_as">
                                 <a href="#">Save a Copy...</a>
                             </li>
+                            <li class="local_storage" title="Open or Clear recovered data from local storage">
+                                <a href="#">Local storage...</a>
+                            </li>
                             <li class="export_json">
                                 <a href="#">Export as JSON...</a>
                             </li>
@@ -671,9 +674,6 @@
                             </li>
                             <li class="delete_figure">
                                 <a href="#">Delete</a>
-                            </li>
-                            <li class="local_storage" title="Open or Clear recovered data from local storage">
-                                <a href="#">Local storage...</a>
                             </li>
                             <li class="paper_setup">
                                 <a href="#">Paper Setup...</a>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -672,6 +672,9 @@
                             <li class="delete_figure">
                                 <a href="#">Delete</a>
                             </li>
+                            <li class="local_storage" title="Open or Clear recovered data from local storage">
+                                <a href="#">Local storage...</a>
+                            </li>
                             <li class="paper_setup">
                                 <a href="#">Paper Setup...</a>
                             </li>

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     # index 'home page' of the figure app
     url(r'^$', views.index, name='figure_index'),
     url(r'^new/$', views.index, name='new_figure'),
+    url(r'^recover/$', views.index, name='recover_figure'),
     url(r'^open/$', views.index, name='open_figure'),
     url(r'^file/(?P<file_id>[0-9]+)/$', views.index, name='load_figure'),
 

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -223,7 +223,7 @@ def render_scaled_region(request, iid, z, t, conn=None, **kwargs):
     return HttpResponse(jpeg_data, content_type='image/jpeg')
 
 
-@login_required(setGroupContext=True)
+@login_required()
 def save_web_figure(request, conn=None, **kwargs):
     """
     Saves 'figureJSON' in POST as an original file. If 'fileId' is specified
@@ -284,7 +284,6 @@ def save_web_figure(request, conn=None, **kwargs):
         # Create new file
         # Try to set Group context to the same as first image
         curr_gid = conn.SERVICE_OPTS.getOmeroGroup()
-        conn.SERVICE_OPTS.setOmeroGroup('-1')
         i = None
         if first_img_id:
             i = conn.getObject("Image", first_img_id)
@@ -308,8 +307,6 @@ def save_web_figure(request, conn=None, **kwargs):
 
     else:
         # Update existing Original File
-        conn.SERVICE_OPTS.setOmeroGroup('-1')
-        # Following seems to work OK with group -1 (regardless of group ctx)
         fa = conn.getObject("FileAnnotation", file_id)
         if fa is None:
             return Http404("Couldn't find FileAnnotation of ID: %s" % file_id)

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -66,6 +66,7 @@ $(function(){
         routes: {
             "": "index",
             "new(/)": "newFigure",
+            "recover(/)": "recoverFigure",
             "open(/)": "openFigure",
             "file/:id(/)": "loadFigure",
         },
@@ -127,6 +128,11 @@ $(function(){
                 $("#openFigureModal").modal();
             };
             this.checkSaveAndClear(cb);
+        },
+
+        recoverFigure: function() {
+            $(".modal").modal('hide'); // hide any existing dialogs
+            figureModel.recoverFromLocalStorage();
         },
 
         newFigure: function() {

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -314,7 +314,7 @@
                     var buttons = ['Close', 'Export as JSON'];
                     var callback = function(btnText) {
                         if (btnText === "Export as JSON") {
-                            showExporAsJsonModal(figureJSON);
+                            showExportAsJsonModal(figureJSON);
                         }
                     }
                     figureConfirmDialog(errorTitle, message, buttons, callback);

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -297,6 +297,27 @@
                     if (options.success) {
                         options.success(data);
                     }
+                })
+                .error(function(rsp){
+                    console.log('Save Error', rsp.responseText);
+                    var errorTitle = `${rsp.status} ${rsp.statusText}`;
+                    var loginMsg = `
+                        <p>Please <a href="${WEBINDEX_URL}" target="_blank">open the webclient in a new tab</a>
+                        to check you are logged-in.</p>`
+                    var message = `
+                        ${rsp.status === 403 ? loginMsg : ""}
+                        <p>To ensure you don't lose the current Figure, please <b>Export as JSON</b>, then copy
+                        the figure data and save it on your machine.</p>
+                        <p>You may need to refresh this page.</p>
+                        <p>You can recreate the Figure using <b>File > Import from JSON</b>, then paste in the figure data.</p>
+                    `;
+                    var buttons = ['Close', 'Export as JSON'];
+                    var callback = function(btnText) {
+                        if (btnText === "Export as JSON") {
+                            showExporAsJsonModal(figureJSON);
+                        }
+                    }
+                    figureConfirmDialog(errorTitle, message, buttons, callback);
                 });
         },
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -266,19 +266,12 @@
 
         // handle /recover/ page
         recoverFromLocalStorage: function() {
-            var storage = window.localStorage;
-            var recoveredFigure = storage.getItem(LOCAL_STORAGE_RECOVERED_FIGURE);
-            var figureObject;
-            try {
-                figureObject = JSON.parse(recoveredFigure);
-            } catch (e) {
-                console.log("recovered Figure not valid JSON " + recoveredFigure);
-            }
+            var figureObject = recoverFigureFromStorage();
             if (!figureObject) {
                 var message = "No valid figure was found in local storage."
                 figureConfirmDialog("No Figure found", message, ["OK"]);
             } else {
-                this.figure_fromJSON(recoveredFigure);
+                this.figure_fromJSON(JSON.stringify(figureObject));
                 var html = `<p>This figure has been recovered from the browser's local storage.</p>
                         <p>If you wish to clear this data from local storage, click File > Local storage.</p>`
                 figureConfirmDialog(

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -320,9 +320,8 @@
                     var storage = window.localStorage;
                     storage.setItem(LOCAL_STORAGE_RECOVERED_FIGURE, JSON.stringify(figureJSON));
 
-                    var errorTitle = `Save Error`;
+                    var errorTitle = `Save Error: ${rsp.status}`;
                     var message = `
-                        <p>${rsp.status} ${rsp.statusText}</p>
                         <p>The current figure has failed to Save to OMERO.</p>
                         <p>A copy has been placed in your browser's local storage and will be
                         recovered when you reload the app. Reloading will also check your

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -279,17 +279,10 @@
                 figureConfirmDialog("No Figure found", message, ["OK"]);
             } else {
                 this.figure_fromJSON(recoveredFigure);
-                var recoverDialogCallback = function(btnText) {
-                    if (btnText === "Clear local storage") {
-                        storage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE)
-                    }
-                }
-                var buttons = ["Clear local storage", "OK"];
                 var html = `<p>This figure has been recovered from the browser's local storage.</p>
-                        <p>If you wish to clear this data from local storage, click 'Clear local storage'.</p>`
+                        <p>If you wish to clear this data from local storage, click File > Local storage.</p>`
                 figureConfirmDialog(
-                    "Figure recovered",
-                    html, buttons, recoverDialogCallback);
+                    "Figure recovered", html, ["OK"]);
             }
         },
 
@@ -337,7 +330,8 @@
                     var errorTitle = `Save Error`;
                     var message = `
                         <p>${rsp.status} ${rsp.statusText}</p>
-                        <p>The current figure has been saved to local storage and will be
+                        <p>The current figure has failed to Save to OMERO.</p>
+                        <p>A copy has been placed in your browser's local storage and will be
                         recovered when you reload the app. Reloading will also check your
                         connection to OMERO.
                         </p>
@@ -346,7 +340,6 @@
                     var callback = function(btnText) {
                         if (btnText === "Reload in new Tab") {
                             var recoverUrl = BASE_WEBFIGURE_URL + 'recover/';
-
                             window.open(WEBLOGIN_URL + '?url=' + recoverUrl, '_blank')
                         }
                     }

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -95,6 +95,7 @@
             "click .export_json": "export_json",
             "click .import_json": "import_json",
             "click .delete_figure": "delete_figure",
+            "click .local_storage": "local_storage",
             "click .paper_setup": "paper_setup",
             "click .export-options a": "select_export_option",
             "click .zoom-paper-to-fit": "zoom_paper_to_fit",
@@ -373,6 +374,20 @@
                 this.model.set("unsaved", false);   // prevent "Save?" dialog
                 this.figureFiles.deleteFile(fileId, figName);
             }
+        },
+
+        local_storage: function(event) {
+            var buttons = ['Cancel', 'Clear Storage', 'Recover Figure'];
+            var callback = function (btnText) {
+                if (btnText === "Clear Storage") {
+                    window.localStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
+                } else if (btnText === "Recover Figure") {
+                    window.location = BASE_WEBFIGURE_URL + 'recover/';
+                }
+            }
+            var message = `<p>Any figure that fails to Save is stored in the browser's local storage.
+                You can Clear local storage or Recover a figure from local storage with the options below:</p>`
+            figureConfirmDialog("Local Storage", message, buttons, callback);
         },
 
         open_figure: function(event) {

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -335,7 +335,15 @@
         },
 
         local_storage: function (event) {
-            var buttons = ['Cancel', 'Clear Storage', 'Recover Figure'];
+            var buttons = ['Close'];
+            let figureObject = recoverFigureFromStorage();
+            var message = `<p>Any figure that fails to Save is stored in the browser's local storage.</p>`;
+            if (figureObject) {
+                buttons = buttons.concat(['Clear Storage', 'Recover Figure']);
+                message += `<p>You can Clear local storage or Recover the figure from local storage with the options below:</p>`;
+            } else {
+                message += `<p>No Figure currectly found.</p>`;
+            }
             var callback = function (btnText) {
                 if (btnText === "Clear Storage") {
                     window.localStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
@@ -343,8 +351,6 @@
                     window.location = BASE_WEBFIGURE_URL + 'recover/';
                 }
             }
-            var message = `<p>Any figure that fails to Save is stored in the browser's local storage.
-                You can Clear local storage or Recover a figure from local storage with the options below:</p>`
             figureConfirmDialog("Local Storage", message, buttons, callback);
         },
 

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -334,6 +334,20 @@
             this.model.nudge_up();
         },
 
+        local_storage: function (event) {
+            var buttons = ['Cancel', 'Clear Storage', 'Recover Figure'];
+            var callback = function (btnText) {
+                if (btnText === "Clear Storage") {
+                    window.localStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
+                } else if (btnText === "Recover Figure") {
+                    window.location = BASE_WEBFIGURE_URL + 'recover/';
+                }
+            }
+            var message = `<p>Any figure that fails to Save is stored in the browser's local storage.
+                You can Clear local storage or Recover a figure from local storage with the options below:</p>`
+            figureConfirmDialog("Local Storage", message, buttons, callback);
+        },
+
         goto_newfigure: function(event) {
             if (event) event.preventDefault();
             $(".modal").modal('hide');
@@ -374,20 +388,6 @@
                 this.model.set("unsaved", false);   // prevent "Save?" dialog
                 this.figureFiles.deleteFile(fileId, figName);
             }
-        },
-
-        local_storage: function(event) {
-            var buttons = ['Cancel', 'Clear Storage', 'Recover Figure'];
-            var callback = function (btnText) {
-                if (btnText === "Clear Storage") {
-                    window.localStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
-                } else if (btnText === "Recover Figure") {
-                    window.location = BASE_WEBFIGURE_URL + 'recover/';
-                }
-            }
-            var message = `<p>Any figure that fails to Save is stored in the browser's local storage.
-                You can Clear local storage or Recover a figure from local storage with the options below:</p>`
-            figureConfirmDialog("Local Storage", message, buttons, callback);
         },
 
         open_figure: function(event) {

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -342,7 +342,7 @@
                 buttons = buttons.concat(['Clear Storage', 'Recover Figure']);
                 message += `<p>You can Clear local storage or Recover the figure from local storage with the options below:</p>`;
             } else {
-                message += `<p>No Figure currectly found.</p>`;
+                message += `<p>No Figure currently found.</p>`;
             }
             var callback = function (btnText) {
                 if (btnText === "Clear Storage") {

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -471,11 +471,7 @@
 
         export_json: function(event) {
             event.preventDefault();
-
-            var figureJSON = this.model.figure_toJSON(),
-                figureText = JSON.stringify(figureJSON);
-            $('#exportJsonModal').modal('show');
-            $('#exportJsonModal textarea').text(figureText);
+            showExportAsJsonModal(this.model.figure_toJSON());
         },
         
         import_json: function(event) {

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -59,6 +59,18 @@ var showExportAsJsonModal = function(figureJSON) {
     $('#exportJsonModal textarea').text(figureText);
 }
 
+var recoverFigureFromStorage = function() {
+    var storage = window.localStorage;
+    var recoveredFigure = storage.getItem(LOCAL_STORAGE_RECOVERED_FIGURE);
+    var figureObject;
+    try {
+        figureObject = JSON.parse(recoveredFigure);
+    } catch (e) {
+        console.log("recovered Figure not valid JSON " + recoveredFigure);
+    }
+    return figureObject;
+}
+
 var figureConfirmDialog = function(title, message, buttons, callback) {
     var $confirmModal = $("#confirmModal"),
         $title = $(".modal-title", $confirmModal),

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -53,6 +53,11 @@ if (!String.prototype.endsWith)
                          searchStr.length) === searchStr;
   };
 
+var showExporAsJsonModal = function(figureJSON) {
+    var figureText = JSON.stringify(figureJSON);
+    $('#exportJsonModal').modal('show');
+    $('#exportJsonModal textarea').text(figureText);
+}
 
 var figureConfirmDialog = function(title, message, buttons, callback) {
     var $confirmModal = $("#confirmModal"),

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -53,7 +53,7 @@ if (!String.prototype.endsWith)
                          searchStr.length) === searchStr;
   };
 
-var showExporAsJsonModal = function(figureJSON) {
+var showExportAsJsonModal = function(figureJSON) {
     var figureText = JSON.stringify(figureJSON);
     $('#exportJsonModal').modal('show');
     $('#exportJsonModal textarea').text(figureText);


### PR DESCRIPTION
Fixes #365 and fixes #352 

This handles errors when saving figures.

EDIT - we now store the current figure JSON in local storage and direct the user to login page which redirects to /figure/recover/ page which will load the recovered figure.

<img width="585" alt="Screenshot 2021-01-10 at 23 42 32" src="https://user-images.githubusercontent.com/900055/104138671-933ab080-539d-11eb-8612-8fcf42bd2781.png">


To test:
 - Create or Edit a figure
 - In another tab, log out of the webclient
 - Save the Figure - the above dialog should be shown
 - Clicking Reload button will open the webclient login page, then redirect you to `figure/recover/` page which should open the recovered file (unsaved). A dialog will ask if you want to clear the figure from local storage.
 - When you save the recovered figure, it will create a new file, to make sure we don't overwrite another version of the saved file.
 - File > Local Storage... gives you options to Clear local storage or to Recover a figure from local storage.
