### PR TITLE
Show group info

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -44,11 +44,13 @@
         LIST_WEBFIGURES_URL = "{% url 'list_web_figures' %}",
         DELETE_WEBFIGURE_URL = "{% url 'delete_web_figure' %}",
         MAKE_WEBFIGURE_URL = "{% url 'make_web_figure' %}",
+        API_BASE_URL_V0 = "{% url 'api_base' '0' %}",
         ACTIVITIES_JSON_URL = "{% url 'activities_json' %}",
         WEBGATEWAYINDEX = "{% url 'webgateway' %}",
         WEBINDEX_URL = "{% url 'webindex' %}",
         ROIS_JSON_URL = "{% url 'api_rois' '0' %}",
         USER_FULL_NAME = "{{ userFullName }}",
+        USER_ID = {{ userId }},
         LENGTH_UNITS = {{ lengthUnits|safe }},
         IS_PUBLIC_USER = {% if isPublicUser %}true{% else %}false{% endif %},
         // Images larger than this are 'big' tiled images
@@ -191,6 +193,26 @@
                 <form class="paperSetupForm" role="form">
                     <div class="modal-body">
                         <!-- Content added from paper_setup_modal_template -->
+                    </div>
+                    <div class="modal-footer" style="margin-top: 0">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">OK</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <!-- chgrp Modal -->
+    <div class="modal" id="chgrpModal" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">Move Figure to Group</h4>
+                </div>
+                <form class="chgrpForm" role="form">
+                    <div class="modal-body">
+                        <!-- Content added -->
                     </div>
                     <div class="modal-footer" style="margin-top: 0">
                         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -678,6 +700,9 @@
                             </li>
                             <li class="delete_figure">
                                 <a href="#">Delete</a>
+                            </li>
+                            <li class="chgrp_figure">
+                                <a href="#">Move Figure to Group...</a>
                             </li>
                             <li class="paper_setup">
                                 <a href="#">Paper Setup...</a>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -525,7 +525,7 @@
     </div>
     <!-- File Open Modal -->
     <div class="modal" id="openFigureModal" tabindex="-1" role="dialog" aria-labelledby="addImagesLabel" aria-hidden="true">
-        <div class="modal-dialog" style="width:800px">
+        <div class="modal-dialog" style="width:850px">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -536,8 +536,8 @@
                         <table class="table table-condensed">
                             <thead>
                                 <tr>
-                                    <th style="width:10%"></th>
-                                    <th style="width:50%">
+                                    <th style="width:7%"></th>
+                                    <th style="width:47%">
                                         <form class="form-inline" role="form">
                                             <div class="form-group">
                                                 <label class="col-sm-2 control-label">Name</label>
@@ -553,7 +553,7 @@
                                             </div>
                                         </form>
                                     </th>
-                                    <th style="width:25%">
+                                    <th style="width:22%">
                                         Created
                                         <button type="button" class="btn btn-link btn-sm sort-created sort table-sort-btn">
                                             <span class="glyphicon glyphicon-chevron-up"></span>
@@ -562,13 +562,23 @@
                                             <span class="glyphicon glyphicon-chevron-down"></span>
                                         </button>
                                     </th>
-                                    <th style="width:15%">
+                                    <th style="width:12%">
                                         <div class="btn-group" title="Filter files by owner">
-                                            <button id="file-owner-btn" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                                 <b>Owner</b> <span class="caret"></span>
                                             </button>
                                             <ul id="owner-menu" class="dropdown-menu pull-right" role="menu">
                                                 <!-- owners added here -->
+                                            </ul>
+                                        </div>
+                                    </th>
+                                    <th style="width:12%">
+                                        <div class="btn-group" title="Filter files by group">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                                                <b>Group</b> <span class="caret"></span>
+                                            </button>
+                                            <ul id="group-menu" class="dropdown-menu pull-right" role="menu">
+                                                <!-- groups added here -->
                                             </ul>
                                         </div>
                                     </th>

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -74,4 +74,7 @@ urlpatterns = [
 
     url(r'^roiCount/(?P<image_id>[0-9]+)/$', views.roi_count,
         name='figure_roiCount'),
+
+    # POST to change figure to new group with ann_id and group_id
+    url(r'chgrp/$', views.chgrp, name='figure_chgrp')
 ]

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -76,5 +76,9 @@ urlpatterns = [
         name='figure_roiCount'),
 
     # POST to change figure to new group with ann_id and group_id
-    url(r'chgrp/$', views.chgrp, name='figure_chgrp')
+    url(r'chgrp/$', views.chgrp, name='figure_chgrp'),
+
+    # Get group and owner info for multiple images. ?image=1,2,3
+    url(r'images_details/', views.images_details,
+        name="figure_images_details")
 ]

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -446,8 +446,11 @@ def list_web_figures(request, conn=None, **kwargs):
                 o.lastName as lastName,
                 e.time as time,
                 f.name as name,
+                g.id as group_id,
+                g.name as group_name,
                 obj as obj_details_permissions)
             from FileAnnotation obj
+            join obj.details.group as g
             join obj.details.owner as o
             join obj.details.creationEvent as e
             join obj.file.details as p
@@ -466,6 +469,10 @@ def list_web_figures(request, conn=None, **kwargs):
             'name': unwrap(fa['name']),
             'description': unwrap(fa['desc']),
             'ownerFullName': "%s %s" % (first_name, last_name),
+            'group': {
+                'id': fa['group_id'],
+                'name': fa['group_name']
+            },
             'creationDate': time.mktime(date.timetuple()),
             'canEdit': fa['obj_details_permissions'].get('canEdit')
         }

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -96,6 +96,7 @@ def index(request, file_id=None, conn=None, **kwargs):
 
     context = {'scriptMissing': script_missing,
                'userFullName': user_full_name,
+               'userId': user.id,
                'maxPlaneSize': max_plane_size,
                'lengthUnits': json.dumps(length_units),
                'isPublicUser': is_public_user,
@@ -386,6 +387,10 @@ def load_web_figure(request, file_id, conn=None, **kwargs):
         # parse the json, so we can add info...
         json_data = json.loads(figure_json)
         json_data['canEdit'] = owner_id == conn.getUserId()
+        json_data['group'] = {
+            'id': file_ann.getDetails().group.id.val,
+            'name': file_ann.getDetails().group.name.val
+        }
         # Figure name may not be populated: check in description...
         if 'figureName' not in json_data:
             desc = file_ann.getDescription()

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -602,3 +602,29 @@ def chgrp(request, conn=None, **kwargs):
         rv['parameters'] = ", ".join(params)
         rv['error'] = "%s %s" % (rsp.name, ", ".join(params))
     return JsonResponse(rv)
+
+
+@login_required()
+def images_details(request, conn=None, **kwargs):
+
+    imgs = request.GET.get('image', '')
+    img_ids = [int(i) for i in imgs.split(',') if len(i) > 0]
+
+    data = []
+    for image in conn.getObjects('Image', img_ids):
+        details = image.getDetails()
+        data.append({
+            'id': image.id,
+            'name': image.name,
+            'group': {
+                'id': details.group.id.val,
+                'name': details.group.name.val
+            },
+            'owner': {
+                'id': details.owner.id.val,
+                'firstName': details.owner.firstName.val,
+                'lastName': details.owner.lastName.val
+            }
+        })
+
+    return JsonResponse({'data': data})

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -588,7 +588,7 @@ def chgrp(request, conn=None, **kwargs):
             handle, loops=10, ms=500,
             failonerror=True, failontimeout=False, closehandle=False)
         rsp = handle.getResponse()
-    except:
+    except Exception:
         rv['error'] = traceback.format_exc()
     finally:
         if handle is not None:

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -65,8 +65,7 @@
             var name = data.figureName || "UN-NAMED",
                 n = {'fileId': data.fileId,
                     'figureName': name,
-                    'groupId': data.group.id,
-                    'groupName': data.group.name,
+                    'groupId': data.group ? data.group.id : undefined,
                     'canEdit': data.canEdit,
                     'paper_width': data.paper_width,
                     'paper_height': data.paper_height,
@@ -305,6 +304,7 @@
         clearFigure: function() {
             var figureModel = this;
             figureModel.unset('fileId');
+            figureModel.unset('groupId');
             figureModel.delete_panels();
             figureModel.unset("figureName");
             figureModel.set(figureModel.defaults);

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -65,6 +65,8 @@
             var name = data.figureName || "UN-NAMED",
                 n = {'fileId': data.fileId,
                     'figureName': name,
+                    'groupId': data.group.id,
+                    'groupName': data.group.name,
                     'canEdit': data.canEdit,
                     'paper_width': data.paper_width,
                     'paper_height': data.paper_height,

--- a/src/js/views/chgrp_modal_view.js
+++ b/src/js/views/chgrp_modal_view.js
@@ -1,0 +1,93 @@
+
+
+var ChgrpModalView = Backbone.View.extend({
+
+    el: $("#chgrpModal"),
+
+    // template: JST["src/templates/modal_dialogs/chgrp_modal.html"],
+
+    model: FigureModel,
+
+    targetGroups: [],
+
+    initialize: function () {
+
+        var self = this;
+
+        this.enableSubmit(false);
+        // Here we handle init of the dialog when it's shown...
+        $("#chgrpModal").bind("show.bs.modal", function () {
+            $('#chgrpModal .modal-body').html("");
+            self.loadGroups();
+        });
+    },
+
+    events: {
+        "click .chgrpForm input": "inputClicked",
+        "submit .chgrpForm": "handleSubmit"
+    },
+
+    loadGroups: function() {
+        var groupId = this.model.get('groupId');
+        var url = `${API_BASE_URL_V0}m/experimenters/${USER_ID}/experimentergroups/`;
+        $.getJSON(url, function(data){
+            this.targetGroups = data.data.map(group => {return {id: group['@id'], name: group.Name}})
+                .filter(group => group.id != groupId && group.name != 'user');
+            this.render();
+        }.bind(this));
+    },
+
+    inputClicked: function() {
+        this.enableSubmit(true);
+    },
+
+    // we disable Submit when dialog is shown, enable when Group chosen
+    enableSubmit: function (enabled) {
+        var $okBtn = $('button[type="submit"]', this.$el);
+        if (enabled) {
+            $okBtn.prop('disabled', false);
+            $okBtn.prop('title', 'Move to Group');
+        } else {
+            $okBtn.prop('disabled', 'disabled');
+            $okBtn.prop('title', 'No Group selected');
+        }
+    },
+
+    handleSubmit: function (event) {
+        event.preventDefault();
+        var group_id = parseInt($('input[name="target_group"]:checked', this.$el).val());
+        var group_name = this.targetGroups.filter(group => group.id === group_id)[0].name;
+        var fileId = this.model.get('fileId');
+        var url = BASE_WEBFIGURE_URL + 'chgrp/';
+        this.enableSubmit(false);
+        setTimeout(function(){
+            $('#chgrpModal .modal-body').append("<p>Moving to Group: " + group_name + "...</p>");
+        }, 1000);
+        $.post(url, { group_id: group_id, ann_id: fileId})
+            .done(function (data) {
+                $("#chgrpModal").modal('hide');
+                if (data.success) {
+                    this.model.set({groupId: group_id, groupName: group_name});
+                    figureConfirmDialog("Success", "Figure moved to Group: " + group_name, ["OK"]);
+                } else {
+                    var errorMsg = data.error || "No error message available";
+                    figureConfirmDialog("Move Failed", errorMsg, ["OK"]);
+                }
+            }.bind(this));
+    },
+
+    render: function() {
+        var html = '<p>This figure is currently in Group: <strong>' + this.model.get('groupName') + '</strong></p>';
+        if (this.targetGroups.length === 0) {
+            html += "<p>No other Groups available (You are not a member of any other groups)</p>";
+        } else {
+            html += "<p>Move to Group...</p>";
+            html += this.targetGroups.map(group => `<div class="radio">
+                <label><input type="radio" name="target_group" value="${group.id}">
+                    ${group.name}
+                </label></div>`)
+                .join("\n");
+        }
+        $('.modal-body', this.$el).html(html);
+    }
+});

--- a/src/js/views/chgrp_modal_view.js
+++ b/src/js/views/chgrp_modal_view.js
@@ -110,7 +110,11 @@ var ChgrpModalView = Backbone.View.extend({
             var groupName = this.imagesByGroup[groupId][0].group.name;
             return `
                 <b>${groupName}</b>
-                (<a target="_blank" href="${WEBINDEX_URL}?show=image-${imgIds.join('|image-')}">${imgIds.length} image${imgIds.length == 1 ? '' : 's'}</a>)`}).join(", ") + '.</p>';
+                (<a target="_blank" href="${WEBINDEX_URL}?show=image-${imgIds.join('|image-')}">${imgIds.length} image${imgIds.length == 1 ? '' : 's'}</a>)`
+            }
+        ).join(", ") + '.</p>';
+        html += `<p><b>NB:</b> If a figure contains images from a <i>different</i> group, it is possible that some
+            users may be able to open the figure but not see those images in it.</p>`
 
         var targetGroups = this.omeroGroups.filter(group => group.id != groupId);
         if (targetGroups.length === 0) {

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -15,6 +15,7 @@
             new SetIdModalView({model: this.model});
             new PaperSetupModalView({model: this.model});
             new CropModalView({model: this.model});
+            new ChgrpModalView({ model: this.model });
             new RoiModalView({model: this.model});
             new DpiModalView({model: this.model});
             new LegendView({model: this.model});
@@ -95,6 +96,7 @@
             "click .export_json": "export_json",
             "click .import_json": "import_json",
             "click .delete_figure": "delete_figure",
+            "click .chgrp_figure": "chgrp_figure",
             "click .paper_setup": "paper_setup",
             "click .export-options a": "select_export_option",
             "click .zoom-paper-to-fit": "zoom_paper_to_fit",
@@ -373,6 +375,12 @@
                 this.model.set("unsaved", false);   // prevent "Save?" dialog
                 this.figureFiles.deleteFile(fileId, figName);
             }
+        },
+
+        chgrp_figure: function (event) {
+            event.preventDefault();
+            $(".modal").modal('hide');
+            $("#chgrpModal").modal('show');
         },
 
         open_figure: function(event) {

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -1,6 +1,6 @@
 
 //
-// Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+// Copyright (C) 2014-2020 University of Dundee & Open Microscopy Environment.
 // All rights reserved.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -39,6 +39,11 @@ var FigureFile = Backbone.Model.extend({
     isVisible: function(filter) {
         if (filter.owner) {
             if (this.get('ownerFullName') !== filter.owner) {
+                return false;
+            }
+        }
+        if (filter.group) {
+            if (this.get('group').name !== filter.group) {
                 return false;
             }
         }
@@ -133,6 +138,7 @@ var FileListView = Backbone.View.extend({
         "click .sort-name": "sort_name",
         "click .sort-name-reverse": "sort_name_reverse",
         "click .pick-owner": "pick_owner",
+        "click .pick-group": "pick_group",
         "keyup #file-filter": "filter_files",
         "click .refresh-files": "refresh_files",
     },
@@ -197,6 +203,17 @@ var FileListView = Backbone.View.extend({
         this.render();
     },
 
+    pick_group: function (event) {
+        event.preventDefault()
+        var group = $(event.target).text();
+        if (group != " -- Show All -- ") {
+            this.group = group;
+        } else {
+            delete this.group;
+        }
+        this.render();
+    },
+
     render:function () {
         var self = this,
             filter = {},
@@ -204,6 +221,9 @@ var FileListView = Backbone.View.extend({
             currentFileId = this.figureModel.get('fileId');
         if (this.owner && this.owner.length > 0) {
             filter.owner = this.owner;
+        }
+        if (this.group && this.group.length > 0) {
+            filter.group = this.group;
         }
         if (filterVal.length > 0) {
             filter.name = filterVal.toLowerCase();
@@ -223,7 +243,7 @@ var FileListView = Backbone.View.extend({
                 self.$tbody.prepend(e);
             }
         });
-        owners = this.model.pluck("ownerFullName");
+        var owners = this.model.pluck("ownerFullName");
         owners = _.uniq(owners, false);
         // Sort by last name
         owners.sort(function compare(a, b) {
@@ -239,6 +259,15 @@ var FileListView = Backbone.View.extend({
             ownersHtml += "<li><a class='pick-owner' href='#'>" + owner + "</a></li>";
         });
         $("#owner-menu").html(ownersHtml);
+
+        // render groups chooser
+        var groups = this.model.pluck("group");
+        var groupNames = groups.map(function(g){return g.name});
+        groupNames = _.uniq(groupNames, false);
+        groupNames.sort();
+        var groupsHtml = "<li><a class='pick-group' href='#'> -- Show All -- </a></li><li class='divider'></li>";
+        groupsHtml += groupNames.map(function (g) { return "<li><a class='pick-group' href='#'>" + g + "</a></li>"}).join('\n');
+        $("#group-menu").html(groupsHtml);
         return this;
     }
 });

--- a/src/templates/files/figure_file_item.html
+++ b/src/templates/files/figure_file_item.html
@@ -27,3 +27,6 @@
     <td>
         <%= ownerFullName %>
     </td>
+    <td>
+        <%= group.name %>
+    </td>


### PR DESCRIPTION
Fixes #284 to show which groups each Figure is in and allow you to chgrp.

To test:

 - File > Open list now includes groups and allows you to filter by Group just the same as Owner.
 - File > Move Figure to Group... shows a chgrp dialog where you can pick a group to move to. Chgrp should be "instant" (we wait for a response instead of polling for completion) since it's not expected to take long. 
 - This dialog also shows you which group the images in the figure belong to, with links to the images. This should help to ensure you keep the images and figure in same group.

![Screenshot 2020-12-17 at 12 09 52](https://user-images.githubusercontent.com/900055/102486605-32031400-4061-11eb-9f4c-4711c46fe03d.png)

![Screenshot 2020-12-17 at 14 26 52](https://user-images.githubusercontent.com/900055/102500674-78ae3980-4074-11eb-9d7b-4cde22da8dc8.png)
