### PR TITLE
Handle save errors2

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -57,7 +57,7 @@
         // Images larger than this are 'big' tiled images
         MAX_PLANE_SIZE = "{{ maxPlaneSize }}";
 
-    var LOCAL_STORAGE_RECOVERED_FIGURE = "recoveredFigure";
+    var LOCAL_STORAGE_RECOVERED_FIGURE = "recoveredFigure" + USER_ID;
 
     $(document).ready(function() {
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -273,8 +273,9 @@
                 figureConfirmDialog("No Figure found", message, ["OK"]);
             } else {
                 this.figure_fromJSON(JSON.stringify(figureObject));
-                var html = `<p>This figure has been recovered from the browser's local storage.</p>
-                        <p>If you wish to clear this data from local storage, click File > Local storage.</p>`
+                clearFigureFromStorage();
+                var html = `<p>This figure has been recovered from the browser's local storage and
+                        the local storage cleared.</p>`;
                 figureConfirmDialog(
                     "Figure recovered", html, ["OK"]);
             }
@@ -318,16 +319,14 @@
                     console.log('Save Error', rsp.responseText);
 
                     // Save to local storage to avoid data loss
-                    var storage = window.localStorage;
-                    storage.setItem(LOCAL_STORAGE_RECOVERED_FIGURE, JSON.stringify(figureJSON));
+                    saveFigureToStorage(figureJSON);
 
                     var errorTitle = `Save Error: ${rsp.status}`;
                     var message = `
                         <p>The current figure has failed to Save to OMERO.</p>
-                        <p>A copy has been placed in your browser's local storage and will be
-                        recovered when you reload the app. Reloading will also check your
-                        connection to OMERO.
-                        </p>
+                        <p>A copy has been placed in your browser's local storage for this session
+                        and can be recovered with File > Local Storage or by reloading the app.</p>
+                        <p>Reloading will also check your connection to OMERO.</p>
                     `;
                     var buttons = ['Close', 'Reload in new Tab'];
                     var callback = function(btnText) {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -901,6 +901,4 @@
                 });
             }.bind(this));
         }
-
-        // localStorage: new Backbone.LocalStorage("figureShop-backbone")
     });

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -348,7 +348,7 @@
             }
             var callback = function (btnText) {
                 if (btnText === "Clear Storage") {
-                    window.localStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
+                    clearFigureFromStorage();
                 } else if (btnText === "Recover Figure") {
                     window.location = BASE_WEBFIGURE_URL + 'recover/';
                 }

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -59,8 +59,16 @@ var showExportAsJsonModal = function(figureJSON) {
     $('#exportJsonModal textarea').text(figureText);
 }
 
+var saveFigureToStorage = function (figureJSON) {
+    window.sessionStorage.setItem(LOCAL_STORAGE_RECOVERED_FIGURE, JSON.stringify(figureJSON));
+}
+
+var clearFigureFromStorage = function() {
+    window.sessionStorage.removeItem(LOCAL_STORAGE_RECOVERED_FIGURE);
+}
+
 var recoverFigureFromStorage = function() {
-    var storage = window.localStorage;
+    var storage = window.sessionStorage;
     var recoveredFigure = storage.getItem(LOCAL_STORAGE_RECOVERED_FIGURE);
     var figureObject;
     try {


### PR DESCRIPTION
This is a follow-up to #415. cc @jburel 

NB: this is on top of #416 (needed the new code from that PR), so that should be merged first.

To test:
 - When a figure is recovered, the figure is cleared from local storage
 - We use 'sessionStorage' for recovering figures. This is cleared when you quit the browser
 - Figure is saved in a per-user storage.