### PR TITLE
Rois pagination

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -309,7 +309,7 @@
                                 <!-- ROIs loaded here... -->
                                 </tbody>
                             </table>
-                            <button style="float: right" class="btn btn-sm btn-default loadRoiRects">Load ROIs</button>
+                            <button style="float: right" class="btn btn-sm btn-default loadRoiRects">Load More...</button>
                             <!-- Additional message/status -->
                             <p style="color: #999; margin: 10px" id='cropRoiMessage'></p>
                         </div>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -309,8 +309,9 @@
                                 <!-- ROIs loaded here... -->
                                 </tbody>
                             </table>
-                            <!-- Additional message depends on whether we have any ROIs or not -->
-                            <p id='cropRoiMessage'></p>
+                            <button style="float: right" class="btn btn-sm btn-default loadRoiRects">Load ROIs</button>
+                            <!-- Additional message/status -->
+                            <p style="color: #999; margin: 10px" id='cropRoiMessage'></p>
                         </div>
                         <div class="col-xs-8">
                             <div id="cropViewer">

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -151,13 +151,16 @@
                                 </div>
                             </div>
                         </div>
-                        <div id="roiModalSidebar" class="col-xs-4"
-                                style="padding:0; height:600px; overflow-y:auto">
-                            <div id="roiModalRoiList">
-                                <table style="width: 100%" class="table table-hover table-condensed"></table>
+                        <div id="roiModalSidebar" class="col-xs-4" style="padding: 0">
+                            <span id="roiPageControls" style="color: #999; line-height: 30px;">
+                            </span>
+                            <div style="clear:both; padding: 5px"></div>
+                            <div style="padding:0; height:550px; overflow-y:auto">
+                                <div id="roiModalRoiList">
+                                    <table style="width: 100%" class="table table-hover table-condensed"></table>
+                                </div>
+                                <p id="roiModalTip" style="position:absolute; top:0"></p>
                             </div>
-                              <p id="roiModalTip"></p>
-                            <p id="roiModalTip"></p>
                         </div>
                     </div>
                     <div class="modal-footer" style="margin-top: 0">

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -76,6 +76,9 @@ urlpatterns = [
     url(r'^roiCount/(?P<image_id>[0-9]+)/$', views.roi_count,
         name='figure_roiCount'),
 
+    url(r'^roiRectangles/(?P<image_id>[0-9]+)/$', views.roi_rectangles,
+        name='figure_roiRectangles'),
+
     # POST to change figure to new group with ann_id and group_id
     url(r'chgrp/$', views.chgrp, name='figure_chgrp'),
 

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -580,10 +580,12 @@ def roi_rectangles(request, image_id, conn=None, **kwargs):
     and shapes.class = Rectangle"""
     params = omero.sys.ParametersI()
     params.addLong('image_id', image_id)
-    result = conn.getQueryService().projection(count_query, params, conn.SERVICE_OPTS)
-    totalCount = result[0][0].val
+    result = conn.getQueryService().projection(count_query, params,
+                                               conn.SERVICE_OPTS)
+    total_count = result[0][0].val
 
-    return JsonResponse({'data': json_data, 'meta': {'totalCount': totalCount}})
+    return JsonResponse({'data': json_data,
+                         'meta': {'totalCount': total_count}})
 
 
 @login_required()

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -35,6 +35,7 @@ from omero.model import LengthI
 from omero.model.enums import UnitsLength
 from omero.cmd import ERR, OK
 import omero
+from omero_marshal import get_encoder
 
 from io import BytesIO
 
@@ -541,6 +542,48 @@ def unit_conversion(request, value, from_unit, to_unit, conn=None, **kwargs):
            'symbol': to_value.getSymbol()}
 
     return HttpResponse(json.dumps(rsp), content_type='application/json')
+
+
+@login_required()
+def roi_rectangles(request, image_id, conn=None, **kwargs):
+    """
+    Load ROIs that have Rectangles and marshal with omero_marshal
+
+    Returns similar JSON to /api/ rois, with meta.totalCount
+    Supports pagination with ?offset and ?limit
+    """
+
+    params = omero.sys.ParametersI()
+    params.addLong('image_id', image_id)
+    limit = request.GET.get('limit')
+    offset = request.GET.get('offset', 0)
+    if limit is not None:
+        params.page(int(offset), int(limit))
+    query = """select roi from Roi roi join fetch
+    roi.details.owner as owner join fetch roi.details.creationEvent
+    left outer join fetch roi.shapes as shapes
+    where roi.image.id = :image_id
+    and shapes.class = Rectangle
+    order by roi.id"""
+
+    rois = conn.getQueryService().findAllByQuery(
+        query, params, conn.SERVICE_OPTS)
+
+    json_data = []
+    for roi in rois:
+        encoder = get_encoder(roi.__class__)
+        json_data.append(encoder.encode(roi))
+
+    count_query = """select count(distinct roi) from Roi roi
+    left outer join roi.shapes as shapes
+    where roi.image.id = :image_id
+    and shapes.class = Rectangle"""
+    params = omero.sys.ParametersI()
+    params.addLong('image_id', image_id)
+    result = conn.getQueryService().projection(count_query, params, conn.SERVICE_OPTS)
+    totalCount = result[0][0].val
+
+    return JsonResponse({'data': json_data, 'meta': {'totalCount': totalCount}})
 
 
 @login_required()

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -360,7 +360,7 @@ var CropModalView = Backbone.View.extend({
             var self = this,
                 iid = self.m.get('imageId');
             var offset = this.roisPageSize * this.roisPage;
-            var url = ROIS_JSON_URL + '?image=' + iid + '&limit=' + self.roisPageSize + '&offset=' + offset;
+            var url = BASE_WEBFIGURE_URL + 'roiRectangles/' + iid + '/?limit=' + self.roisPageSize + '&offset=' + offset;
             $.getJSON(url, function(rsp){
                 data = rsp.data;
                 self.roisLoaded += data.length;

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -51,6 +51,7 @@ var CropModalView = Backbone.View.extend({
                 // Reset ROIs from OMERO...
                 self.roiRects = [];
                 self.roisLoaded = 0;
+                self.roisPage = 0;
                 self.loadRoiRects();
                 // ...along with ROIs from clipboard or on this image in the figure
                 self.showClipboardFigureRois();
@@ -329,7 +330,7 @@ var CropModalView = Backbone.View.extend({
                     }
                 });
             }
-            var msg = "[No Regions copied to clipboard]";
+            var msg = "No Regions copied to clipboard";
             this.renderRois(clipboardRects, ".roisFromClipboard", msg);
 
             // Show Rectangles from panels in figure
@@ -347,7 +348,7 @@ var CropModalView = Backbone.View.extend({
                     });
                 }
             });
-            msg = "[No Rectangular ROIs on selected panel in figure]";
+            msg = "No Rectangular ROIs on selected panel in figure";
             this.renderRois(figureRois, ".roisFromFigure", msg);
         },
 
@@ -438,14 +439,20 @@ var CropModalView = Backbone.View.extend({
                                 'zEnd': zkeys[zkeys.length-1]});
                 }
                 // Show ROIS from OMERO...
-                var msg = "[No rectangular ROIs found on this image in OMERO]";
+                var msg = "No rectangular ROIs found on this image in OMERO";
                 self.renderRois(self.roiRects, ".roisFromOMERO", msg);
 
+                if (self.roisLoaded < self.roisCount) {
+                    // Show the 'Load' button if more are available
+                    $(".loadRoiRects", this.$el).show();
+                } else {
+                    $(".loadRoiRects", this.$el).hide();
+                }
                 $("#cropRoiMessage").html(`Loaded ${self.roisLoaded} / ${self.roisCount} ROIs`);
 
                 self.cachedRois = cachedRois;
             }).error(function(){
-                var msg = "[No rectangular ROIs found on this image in OMERO]";
+                var msg = "No rectangular ROIs found on this image in OMERO";
                 self.renderRois([], ".roisFromOMERO", msg);
             });
         },
@@ -510,7 +517,7 @@ var CropModalView = Backbone.View.extend({
                 html += this.roiTemplate(json);
             }
             if (html.length === 0) {
-                html = "<tr><td colspan='3'>" + msg + "</td></tr>";
+                html = "<tr><td colspan='3' style='color: #999'>" + msg + "</td></tr>";
             }
             $(target + " tbody", this.$el).html(html);
 

--- a/src/js/views/crop_modal_view.js
+++ b/src/js/views/crop_modal_view.js
@@ -8,7 +8,7 @@ var CropModalView = Backbone.View.extend({
 
         model: FigureModel,
 
-        roisPageSize: 10,
+        roisPageSize: 200,
         roisPage: 0,
         roisCount: 0,
         // not all these ROIs will contain Rects

--- a/src/js/views/roi_loader_view.js
+++ b/src/js/views/roi_loader_view.js
@@ -169,6 +169,8 @@ var RoiLoaderView = Backbone.View.extend({
         var html = this.template({
             rois: json,
             showLoadMore: this.totalCount > this.collection.length,
+            totalCount: this.totalCount,
+            count: this.collection.length,
         });
         this.$el.html(html);
 

--- a/src/js/views/roi_loader_view.js
+++ b/src/js/views/roi_loader_view.js
@@ -7,7 +7,10 @@ var RoiLoaderView = Backbone.View.extend({
     shapeTemplate: JST["src/templates/modal_dialogs/roi_modal_shape.html"],
 
     initialize: function(options) {
+        this.render = _.debounce(this.render);
+        this.totalCount = options.totalCount;
         this.panel = options.panel;
+        this.listenTo(this.collection, "add", this.render);
     },
 
     events: {
@@ -163,7 +166,10 @@ var RoiLoaderView = Backbone.View.extend({
         // remove any rois from above with no shapes
         json = json.filter(function(j) {return j});
 
-        var html = this.template({'rois': json});
+        var html = this.template({
+            rois: json,
+            showLoadMore: this.totalCount > this.collection.length,
+        });
         this.$el.html(html);
 
         return this;

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -481,8 +481,10 @@ var RoiModalView = Backbone.View.extend({
                 return;
             }
             var pageCount = Math.ceil(this.omeroRoiCount / this.roisPageSize);
-            var html = `
-                <span>${ this.omeroRoiCount} ROIs: page ${ this.roisPage + 1}/${pageCount}</span>
+            var html = `<span>${ this.omeroRoiCount} ROIs`
+            // Only show pagination controls if needed
+            if (pageCount > 1) {
+                html += `: page ${ this.roisPage + 1}/${pageCount}</span>
                 <div class="btn-group" style="float:right">
                     <button title="Load previous page of ROIs" ${this.roisPage === 0 ? "disabled='disabled'":'' }
                         type="button" class="btn btn-default btn-sm roisPrevPage">
@@ -492,15 +494,23 @@ var RoiModalView = Backbone.View.extend({
                         type="button" class="btn btn-default btn-sm roisNextPage">
                         Next
                     </button>
-                    <button type="button" class="btn btn-default btn-sm dropdown-toggle" title="Export Options" data-toggle="dropdown">
+                    <button type="button" class="btn btn-default btn-sm dropdown-toggle" title="Select page" data-toggle="dropdown">
                         <span class="caret"></span>
                     </button>
-                    <ul class="dropdown-menu export_options" role="menu">
+                    <ul class="dropdown-menu" role="menu">
                     ${
-                        _.range(pageCount).map(p => `<li><a class="roisJumpPage" href="#" data-page="${p}">Page ${p + 1}</a></li>`).join(`\n`)
+                        _.range(pageCount).map(p => `<li>
+                        <a class="roisJumpPage" href="#" data-page="${p}">
+                            <span class="glyphicon glyphicon-ok" ${ this.roisPage !== p ? "style='visibility:hidden'" : ""}></span>
+                            Page ${p + 1}
+                        </a>
+                        </li>`).join(`\n`)
                     }
                     </ul>
                 </div>`
+            } else {
+                html += `</span>`;
+            }
             $("#roiPageControls").html(html).show();
         },
 

--- a/src/templates/modal_dialogs/roi_modal_roi.html
+++ b/src/templates/modal_dialogs/roi_modal_roi.html
@@ -48,14 +48,3 @@
 </tr>
 
 <% }) %>
-
-<tr>
-    <td colspan="4" style="color: #999; vertical-align: middle">
-        Loaded <%= count %> / <%= totalCount %> ROIs
-    </td>
-    <td>
-        <button style="float: right;  <% if (!showLoadMore){ %>display:none<% } %>" class="loadMoreRois btn btn-success btn-sm">
-            Load more...
-        </button>
-    </td>
-</tr>

--- a/src/templates/modal_dialogs/roi_modal_roi.html
+++ b/src/templates/modal_dialogs/roi_modal_roi.html
@@ -48,3 +48,9 @@
 </tr>
 
 <% }) %>
+
+<tr <% if (!showLoadMore){ %>style="display:none" <% } %> >
+    <td colspan="5">
+        <button style="float: right" class="loadMoreRois btn btn-success btn-sm">Load more...</button>
+    </td>
+</tr>

--- a/src/templates/modal_dialogs/roi_modal_roi.html
+++ b/src/templates/modal_dialogs/roi_modal_roi.html
@@ -49,8 +49,13 @@
 
 <% }) %>
 
-<tr <% if (!showLoadMore){ %>style="display:none" <% } %> >
-    <td colspan="5">
-        <button style="float: right" class="loadMoreRois btn btn-success btn-sm">Load more...</button>
+<tr>
+    <td colspan="4" style="color: #999; vertical-align: middle">
+        Loaded <%= count %> / <%= totalCount %> ROIs
+    </td>
+    <td>
+        <button style="float: right;  <% if (!showLoadMore){ %>display:none<% } %>" class="loadMoreRois btn btn-success btn-sm">
+            Load more...
+        </button>
     </td>
 </tr>

--- a/src/templates/shapes/shape_toolbar_template.html
+++ b/src/templates/shapes/shape_toolbar_template.html
@@ -104,7 +104,7 @@
 </div>
 
 
-<div class="btn-group"
+<div class="btn-group" style="float: right"
     <% if (omeroRoiCount > 0) { %>
         title="Load <%=omeroRoiCount%> ROIs from OMERO"
     <% } else { %>


### PR DESCRIPTION
Fixes #334 

Adds support for loading ROIs by page in the main `Edit ROIs` dialog, as well as the `Crop` dialog.

To test ROIs dialog...

 - Find an image that has lots of ROIs - (over 500)
 - Open the `Edit ROIs` dialog and load ROIs from OMERO
 - The first page of 500 ROIs should load (as before) but if you scroll to the bottom, there is some info on how many you've loaded and a "Load More..." button.
 - Clicking the button should load more. When there are no more to load, the button should be hidden. ROIs should be added when you click `Add` button for a ROI.

<img width="384" alt="Screenshot 2021-01-31 at 23 43 51" src="https://user-images.githubusercontent.com/900055/106444120-3babd400-6475-11eb-8a65-40df458bb617.png">


To test Crop dialog...

 - Find an image that has lots of ROIs - (over 200) including Rectangles
 - Open the Crop dialog. The first 200 ROIs are loaded and any Rectangles are shown as thumbnails for picking a crop region (as before).
 - Scrolling to the bottom shows info on how many ROIs loaded and a `Load More...` button. This should load more and the be hidden when no more to load.

<img width="338" alt="Screenshot 2021-01-30 at 22 53 16" src="https://user-images.githubusercontent.com/900055/106370197-a105a500-634f-11eb-83c5-78b748c66a32.png">
