### PR TITLE
Add All button for ROIs table

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -717,7 +717,7 @@ redirect_to:
                     <button id="pdf_inprogress" style="display:none" class="btn btn-primary btn-sm"
                             title="Figure generation in progress..." onClick="return false;">
                         Exporting Figure
-                        <span class="glyphicon glyphicon-refresh"></span>
+                        <span class="glyphicon glyphicon-refresh spinner"></span>
                     </button>
 
                     <a id="pdf_download" href="#" target="_blank"

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -737,7 +737,7 @@
         100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); }
     }
 
-    .navbar-right .glyphicon-refresh, .imgContainer .glyphicon-refresh {
+    .glyphicon-refresh.spinner {
         animation: spin 2s linear infinite;
         padding: 1px 2px 2px 2px;
     }

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -833,7 +833,7 @@
                     <button id="pdf_inprogress" style="display:none" class="btn btn-primary btn-sm"
                             title="Figure generation in progress..." onClick="return false;">
                         Exporting Figure
-                        <span class="glyphicon glyphicon-refresh"></span>
+                        <span class="glyphicon glyphicon-refresh spinner"></span>
                     </button>
 
                     <a id="pdf_download" href="#" target="_blank"

--- a/src/js/models/roi_model.js
+++ b/src/js/models/roi_model.js
@@ -28,7 +28,7 @@ var ShapeModel = Backbone.Model.extend({
             }
         });
         // Convert other attributes
-        _.each(["Points", "MarkerEnd", "MarkerStart", "X", "Y", "RadiusX", "RadiusY", "X1", "Y1", "X2", "Y2", "Width", "Height", "TheZ", "TheT"], function(attr) {
+        _.each(["Points", "MarkerEnd", "MarkerStart", "X", "Y", "RadiusX", "RadiusY", "X1", "Y1", "X2", "Y2", "Width", "Height", "TheZ", "TheT", "TheC"], function(attr) {
             if (shape[attr] !== undefined) {
                 shape[lowerFirst(attr)] = shape[attr];
                 delete shape[attr];

--- a/src/js/views/roi_loader_view.js
+++ b/src/js/views/roi_loader_view.js
@@ -39,7 +39,7 @@ var RoiLoaderView = Backbone.View.extend({
             var shapeId = parseInt($tr.attr('data-shapeId'), 10);
             var shape = this.collection.getShape(shapeId);
             var shapeJson = shape.toJSON();
-            this.collection.trigger('shape_add', [shapeJson]);
+            this.collection.trigger('addShapesFromOmero', [shapeJson]);
         }
     },
 

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -277,7 +277,7 @@ var RoiModalView = Backbone.View.extend({
                         message += ` Added ${ pastedCount } Shapes that lie within the image viewport.`;
                     }
                     if (shapeChannelsInactive.length > 0) {
-                        message += ` <br>Shapes linked to ${shapeChannelsInactive.length === 1 ? 'an inactive channel' : 'inactive channels'}
+                        message += ` <br>As shapes linked to ${shapeChannelsInactive.length === 1 ? 'an inactive channel' : 'inactive channels'}
                             (${shapeChannelsInactive.map(i => i + 1).join(", ")}) were added, so ${shapeChannelsInactive.length === 1 ? 'this channel has' : 'these channels have'} been turned ON.`
                     }
                 }
@@ -285,7 +285,7 @@ var RoiModalView = Backbone.View.extend({
             } else if (pastedCount === 0) {
                 // Always show this message if nothing got added
                 figureConfirmDialog("No ROIs added",
-                "Couldn't add Shape outside of the image viewport. Try zooming out in the Preview panel.", ["OK"]);
+                "Could not add a Shape outside of the image viewport. Try zooming out in the Preview panel.", ["OK"]);
             }
         },
 

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -16,7 +16,7 @@ var RoiModalView = Backbone.View.extend({
         // This gets populated when dialog loads
         omeroRoiCount: 0,
         roisLoaded: false,
-        roisPageSize: 500,
+        roisPageSize: 200,
         roisPage: 0,
 
         initialize: function() {

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -277,8 +277,8 @@ var RoiModalView = Backbone.View.extend({
                         message += ` Added ${ pastedCount } Shapes that lie within the image viewport.`;
                     }
                     if (shapeChannelsInactive.length > 0) {
-                        message += ` <br>Shapes linked to inactive channel${shapeChannelsInactive.length === 1 ? '' : 's'}
-                            (${shapeChannelsInactive.map(i => i + 1).join(", ")}) were added, so these channels have been turned ON.`
+                        message += ` <br>Shapes linked to ${shapeChannelsInactive.length === 1 ? 'an inactive channel' : 'inactive channels'}
+                            (${shapeChannelsInactive.map(i => i + 1).join(", ")}) were added, so ${shapeChannelsInactive.length === 1 ? 'this channel has' : 'these channels have'} been turned ON.`
                     }
                 }
                 figureConfirmDialog(title, message, ["OK"]);

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -137,12 +137,8 @@ var RoiModalView = Backbone.View.extend({
                         }
                     });
                 });
-                if (to_add.length > 0) {
-                    var displayMessage = true;
-                    self.Rois.trigger('shape_add', to_add, displayMessage);
-                } else {
-                    alert("No Shapes found on the current Z / T plane");
-                }
+                var displayMessage = true;
+                self.Rois.trigger('shape_add', to_add, displayMessage);
                 $btn.removeProp('disabled').text(btnText);
             }, 10);
         },
@@ -252,18 +248,29 @@ var RoiModalView = Backbone.View.extend({
                     pastedCount += 1;
                 }
             });
-            if (displayMessage) {
+            if (shapes.length == 0) {
+                figureConfirmDialog("No Shapes found", "No Shapes found on the current Z/T plane", ["OK"]);
+            } else if (displayMessage) {
+                // When using "Add All" ROIs, we give the user a message...
                 var pageCount = Math.ceil(this.omeroRoiCount / this.roisPageSize);
                 var message = `Found ${shapes.length} Shapes on the current Z/T plane`
-                message += (pageCount > 1) ? ` from the current page of ROIs.`: '.';
+                message += (pageCount > 1) ? ` from page ${ this.roisPage + 1} of ROIs.`: '.';
+                var title = "Added ROIs"
                 if (pastedCount == 0) {
-                    message += ` None of these Shapes were within the current viewport. Try zooming out in the Preview panel.`
+                    title = "No ROIs added"
+                    message += ` None of these Shapes were within the image viewport. Try zooming out in the Preview panel.`
                 } else {
-                    message += ` Added ${ pastedCount } Shapes in the current viewport.`;
+                    if (pastedCount === shapes.length) {
+                        message += ` Added all Shapes to the Image.`;
+                    } else {
+                        message += ` Added ${ pastedCount } Shapes that lie within the image viewport.`;
+                    }
                 }
-                alert(message);
+                figureConfirmDialog(title, message, ["OK"]);
             } else if (pastedCount === 0) {
-                alert("Couldn't add Shape outside of current view. Try zooming out in the Preview panel.");
+                // Always show this message if nothing got added
+                figureConfirmDialog("No ROIs added",
+                "Couldn't add Shape outside of the image viewport. Try zooming out in the Preview panel.", ["OK"]);
             }
         },
 

--- a/src/js/views/roi_modal_view.js
+++ b/src/js/views/roi_modal_view.js
@@ -118,6 +118,7 @@ var RoiModalView = Backbone.View.extend({
         addAllShapesToView: function() {
             var $btn = $("button.addAllShapesToView");
             var btnText = $btn.text();
+            var $spinner = $("#add-all-shapes-spinner").show();
             $btn.prop('disabled', true).text("Adding...");
             // Need setTimeout to allow $btn to update first
             setTimeout(()=> {
@@ -140,6 +141,7 @@ var RoiModalView = Backbone.View.extend({
                 var displayMessage = true;
                 self.Rois.trigger('addShapesFromOmero', to_add, displayMessage);
                 $btn.removeProp('disabled').text(btnText);
+                $spinner.hide();
             }, 10);
         },
 

--- a/src/templates/figure_panel_template.html
+++ b/src/templates/figure_panel_template.html
@@ -1,6 +1,6 @@
     <!-- The content of <div class='imagePanel'> for each panel -->
     <div class="imgContainer">
-        <div class="glyphicon glyphicon-refresh"></div>
+        <div class="glyphicon glyphicon-refresh spinner"></div>
         <img class="img_panel" />
         <div id="<%= randomId %>" class="panel_canvas"></div>
     </div>

--- a/src/templates/modal_dialogs/roi_modal_roi.html
+++ b/src/templates/modal_dialogs/roi_modal_roi.html
@@ -4,11 +4,12 @@
     <th></th>
     <th style="line-height: 28px;">Z</th>
     <th style="line-height: 28px;">T</th>
-    <th>
+    <th style="position: relative;">
         <button title="Add all shapes on the current Z/T plane within the image viewport" type="button"
             class="btn btn-success btn-sm addAllShapesToView" style="padding: 3px 6px">
         Add All Shapes
         </button>
+        <span id="add-all-shapes-spinner" style="display:none; position:absolute; right:10px; top:9px" class="glyphicon glyphicon-refresh spinner"></span>
     </th>
 </tr>
 <% _.each(rois, function(roi) { %>

--- a/src/templates/modal_dialogs/roi_modal_roi.html
+++ b/src/templates/modal_dialogs/roi_modal_roi.html
@@ -2,9 +2,14 @@
 <tr>
     <th></th>
     <th></th>
-    <th>Z</th>
-    <th>T</th>
-    <th></th>
+    <th style="line-height: 28px;">Z</th>
+    <th style="line-height: 28px;">T</th>
+    <th>
+        <button title="Add all shapes on the current Z/T plane within the image viewport" type="button"
+            class="btn btn-success btn-sm addAllShapesToView" style="padding: 3px 6px">
+        Add All Shapes
+        </button>
+    </th>
 </tr>
 <% _.each(rois, function(roi) { %>
 


### PR DESCRIPTION
Fixes #335 

This provides an "Add All Shapes" button to add all the shapes that are on the current Z/T plane (or shapes with Z/T unset).
It ignores shapes that are outside the current viewport.

To test:

 - Need an image with various ROIs. NB: I needed this feature with image from idr0079: https://merge-ci.openmicroscopy.org/web/webclient/?show=image-187415 which I want to use for OME2021 figure workshop.
 - Test that "Add All Shapes" button adds all that are on the current Z/T index (as shown in top-left of the Image in the ROI dialog). Any that are outside of the current viewport are silently ignored (try zooming in to a region of the image in the Preview panel before adding ROIs)
 - In contrast, clicking the "Add" button on a particular Shape row should still show a message IF the shape is outside the viewport and is not added.

![Screenshot 2021-04-19 at 14 40 25](https://user-images.githubusercontent.com/900055/115246163-8c9aa280-a11d-11eb-8be9-c4b88ac8ea55.png)
