### PR TITLE
Svg investigation

### DIFF
--- a/omero_figure/templates/figure/svg_test.html
+++ b/omero_figure/templates/figure/svg_test.html
@@ -1,0 +1,219 @@
+<html>
+
+<body>
+
+  <!-- <textarea style="width: 100%; height: 50px;" id="figure_json_input">
+  </textarea> -->
+
+  <div id="svg">
+  </div>
+
+  <textarea style="width: 100%; height: 70px; position: fixed; bottom: 0" id="figure_svg_output">
+  </textarea>
+
+  <button style="position: fixed; bottom: 5px; right: 5px" id="download_svg">Download svg</button>
+
+  <script>
+    var FIGURE_URL = "{% url 'load_web_figure' file_id %}";
+
+    function downloadString(text, fileType, fileName) {
+      // https://gist.github.com/danallison/3ec9d5314788b337b682
+      var blob = new Blob([text], { type: fileType });
+      var a = document.createElement('a');
+      a.download = fileName;
+      a.href = URL.createObjectURL(blob);
+      a.dataset.downloadurl = [fileType, a.download, a.href].join(':');
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function () { URL.revokeObjectURL(a.href); }, 1500);
+    }
+
+    function imgSrc(panel) {
+      const c = panel.channels.map((ch, i) => {
+        const w = ch.window;
+        return `${ch.active ? '' : '-'}${i + 1}|${w.start}:${w.end}$${ch.color}`
+      }).join(",");
+      return `/webgateway/render_image/${panel.imageId}/${panel.theZ}/${panel.theT}/?c=${c}`;
+    }
+
+    const positions = {
+      "top": {},
+      "bottom": {},
+      "left": {},
+      "leftvert": {},
+      "right": {},
+      "topleft": {},
+      "topright": {},
+      "bottomleft": {},
+      "bottomright": {}
+    }
+    const textStyles = {
+      "top": { "text-anchor": "middle" },
+      "bottom": {},
+      "left": {},
+      "leftvert": { "text-anchor": "middle" },
+      "right": {},
+      "topleft": {},
+      "topright": {},
+      "bottomleft": {},
+      "bottomright": {}
+    }
+
+    function getLabelContainerStyles(pos, panel) {
+      console.log('getLabelContainerStyles', pos)
+      switch (pos) {
+        case 'top':
+          return `transform: translate(${panel.width / 2}px, -5px)`;
+        case 'leftvert':
+          return `transform: rotate(-90deg) translate(-${panel.height / 2}px, -5px)`;
+        default:
+          return ''
+      }
+    }
+
+    function labelsSvg(panel) {
+      return Object.keys(positions).map(pos => {
+        return getLabels(panel, pos);
+      }).join("");
+    }
+
+    function getLabels(panel, pos) {
+      const labs = panel.labels.filter(l => l.position === pos);
+      if (labs.length === 0) return "";
+      return `<g class="${pos}"
+        style="${getLabelContainerStyles(pos, panel)}">
+          ${labs.map((l, i) => labelSvg(l, i)).join("")}
+        </g>`;
+    }
+
+    function labelSvg(label, index) {
+      const style = textStyles[label.position];
+      style.transform = `translate(0, -${index * 20}px)`;
+      style['font-size'] = label.size;
+      return `<text
+        style="fill: #${label.color}; ${Object.keys(style).map(k => k + ':' + style[k]).join('; ')}">
+        ${label.text}
+      </text>`
+    }
+
+    function scalebarSvg(panel) {
+      if (!panel.scalebar || !panel.scalebar.show) return '';
+      if (isNaN(panel.pixel_size_x)) return '';
+      const sb = panel.scalebar;
+      const margin = 8;
+      const sbHeight = 3;
+      const textGap = 5;
+      // TODO: handle & convert units "MICROMETER"
+      const lengthPixels = sb.length / panel.pixel_size_x;
+      const ratioOfImgWidth = lengthPixels / panel.orig_width;
+      const imgDisplayWidth = panel.width * (panel.zoom / 100);
+      const sbWidth = ratioOfImgWidth * imgDisplayWidth;
+      const fontSize = parseInt(sb.font_size);    // can be string!
+      // default coords - bottomright
+      let x = panel.width - margin - sbWidth;
+      let y = panel.height - margin - sbHeight;
+      let txtX = panel.width - margin - (sbWidth / 2);
+      let txtY = panel.height - margin - sbHeight - textGap;
+      if (sb.position.includes("top")) {
+        y = margin;
+        txtY = margin + sbHeight + fontSize;
+      }
+      if (sb.position.includes("left")) {
+        x = margin;
+        txtX = margin + (sbWidth / 2);
+      };
+      const label = `<text x="${txtX}" y="${txtY}" style="fill: #${sb.color}; font-size:${fontSize}px" text-anchor="middle">${sb.length} μm</text>`
+      return `<g>
+        <rect x="${x}" y="${y}" width="${sbWidth}" height="${sbHeight}" style="fill: #${sb.color}" />
+        ${label} 
+      </g>`
+    }
+
+
+    function createFigureSvg() {
+      const f = figure_json;
+      const panels = f.panels.map(p => {
+        // add data-sizex and data-sizey for converting to base64 via canvas
+        return `<g transform="translate(${p.x},${p.y})">
+          <image data-sizex="${p.orig_width}" data-sizey="${p.orig_height}" 
+          href="${imgSrc(p)}" style="width: ${p.width}px; height: ${p.height}px;"/>
+          ${labelsSvg(p)}
+          ${scalebarSvg(p)}
+        </g>`
+      });
+
+      return `<svg class="figure" viewBox="0 0 ${f.paper_width} ${f.paper_height}" xmlns="http://www.w3.org/2000/svg">
+        <style>
+        .figure {
+            border: solid black 1px;
+        }
+        text {
+            font: normal 13px sans-serif;
+        }
+        </style>
+        ${panels}
+      </svg>`
+    }
+
+    function renderSvg() {
+      const figureSvg = createFigureSvg();
+      svgContainer.innerHTML = figureSvg;
+      figure_svg_output.value = figureSvg;
+      // listen for image loads...
+
+      function getDataUrl(img) {
+        // Create canvas
+        const canvas = document.createElement('canvas');
+        // data-sizey
+        canvas.width = img.dataset.sizex;
+        canvas.height = img.dataset.sizey;
+        const ctx = canvas.getContext('2d');
+        // Set width and height
+        console.log('img href', img.getAttribute('href'));
+        console.log('img data-sizex', img.dataset.sizex);
+
+        var img1 = new Image();
+        img1.src = img.getAttribute('href');
+        //drawing of the test image - img1
+        img1.onload = function () {
+          //draw background image
+          ctx.drawImage(img1, 0, 0);
+          console.log(canvas.toDataURL('image/jpeg'));
+        };
+      }
+      // Select the image
+      const img = document.querySelector('#my-image');
+      var imgs = document.querySelectorAll("#svg image");
+      imgs.forEach(function (img) {
+        img.addEventListener('load', function (event) {
+          console.log('image loaded...', event.currentTarget)
+          const dataUrl = getDataUrl(event.currentTarget);
+          console.log(dataUrl);
+        });
+      });
+    }
+
+    function downloadFigureSvg() {
+      const figureSvg = createFigureSvg();
+      const fileName = (figure_json.figureName || "testFigure") + ".svg";
+      downloadString(figureSvg, "text/svg", fileName);
+      alert("Downloaded " + fileName);
+    }
+
+    // On Page loads....
+    const svgContainer = document.getElementById("svg");
+    const figure_svg_output = document.getElementById("figure_svg_output");
+    document.getElementById("download_svg").addEventListener("click", downloadFigureSvg);
+
+    fetch(FIGURE_URL).then(rsp => rsp.json()).then((fj => {
+      figure_json = fj;
+      renderSvg();
+    }));
+
+  </script>
+
+</body>
+
+</html>

--- a/omero_figure/templates/figure/svg_test.html
+++ b/omero_figure/templates/figure/svg_test.html
@@ -15,6 +15,7 @@
 
   <script>
     var FIGURE_URL = "{% url 'load_web_figure' file_id %}";
+    var MARGIN = 5;
 
     function downloadString(text, fileType, fileName) {
       // https://gist.github.com/danallison/3ec9d5314788b337b682
@@ -49,25 +50,18 @@
       "bottomleft": {},
       "bottomright": {}
     }
-    const textStyles = {
-      "top": { "text-anchor": "middle" },
-      "bottom": {},
-      "left": {},
-      "leftvert": { "text-anchor": "middle" },
-      "right": {},
-      "topleft": {},
-      "topright": {},
-      "bottomleft": {},
-      "bottomright": {}
-    }
 
-    function getLabelContainerStyles(pos, panel) {
-      console.log('getLabelContainerStyles', pos)
+    function getLabelContainerTransform(pos, panel) {
+      console.log('getLabelContainerTransform', pos)
       switch (pos) {
         case 'top':
-          return `transform: translate(${panel.width / 2}px, -5px)`;
+          return `translate(${panel.width / 2}, -${MARGIN})`;
+        case 'topleft':
+          return `translate(${MARGIN}, ${MARGIN})`;
+        case 'bottomleft':
+          return `translate(${MARGIN}, ${panel.height - MARGIN})`;
         case 'leftvert':
-          return `transform: rotate(-90deg) translate(-${panel.height / 2}px, -5px)`;
+          return `rotate(-90) translate(-${panel.height / 2}, -${MARGIN})`;
         default:
           return ''
       }
@@ -81,21 +75,36 @@
 
     function getLabels(panel, pos) {
       const labs = panel.labels.filter(l => l.position === pos);
+      if (isLabelUpPage({position: pos})){
+        labs.reverse();
+      }
       if (labs.length === 0) return "";
-      return `<g class="${pos}"
-        style="${getLabelContainerStyles(pos, panel)}">
+      return `<text class="${pos}"
+        transform="${getLabelContainerTransform(pos, panel)}">
           ${labs.map((l, i) => labelSvg(l, i)).join("")}
-        </g>`;
+        </text>`;
+    }
+
+    function isLabelCorner(label) {
+      return label.position.includes("left") || label.position.includes("right")
+    }
+
+    function isLabelUpPage(label) {
+      return ["top", "bottomleft", "bottomright"].includes(label.position);
     }
 
     function labelSvg(label, index) {
-      const style = textStyles[label.position];
-      style.transform = `translate(0, -${index * 20}px)`;
-      style['font-size'] = label.size;
-      return `<text
+      let transform = "";
+      const dy = isLabelUpPage(label) ? "-1.2em" : "1.2em";
+      const style = {'font-size': label.size}
+      if (label.position == "top") {
+        style['text-anchor'] = "middle";
+      };
+      return `<tspan
+        x="0" dy="${dy}"
         style="fill: #${label.color}; ${Object.keys(style).map(k => k + ':' + style[k]).join('; ')}">
         ${label.text}
-      </text>`
+      </tspan>`
     }
 
     function scalebarSvg(panel) {
@@ -139,7 +148,7 @@
         return `<g transform="translate(${p.x},${p.y})">
           <image data-sizex="${p.orig_width}" data-sizey="${p.orig_height}" 
           data-href="${imgSrc(p)}"
-          style="width: ${p.width}px; height: ${p.height}px;"/>
+          width="${p.width}px" height="${p.height}px"/>
           ${labelsSvg(p)}
           ${scalebarSvg(p)}
         </g>`

--- a/omero_figure/templates/figure/svg_test.html
+++ b/omero_figure/templates/figure/svg_test.html
@@ -138,13 +138,19 @@
         // add data-sizex and data-sizey for converting to base64 via canvas
         return `<g transform="translate(${p.x},${p.y})">
           <image data-sizex="${p.orig_width}" data-sizey="${p.orig_height}" 
-          href="${imgSrc(p)}" style="width: ${p.width}px; height: ${p.height}px;"/>
+          data-href="${imgSrc(p)}"
+          style="width: ${p.width}px; height: ${p.height}px;"/>
           ${labelsSvg(p)}
           ${scalebarSvg(p)}
         </g>`
       });
 
-      return `<svg class="figure" viewBox="0 0 ${f.paper_width} ${f.paper_height}" xmlns="http://www.w3.org/2000/svg">
+      return `<svg class="figure"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:svg="http://www.w3.org/2000/svg"
+          viewBox="0 0 ${f.paper_width} ${f.paper_height}"
+          >
         <style>
         .figure {
             border: solid black 1px;
@@ -171,35 +177,32 @@
         canvas.height = img.dataset.sizey;
         const ctx = canvas.getContext('2d');
         // Set width and height
-        console.log('img href', img.getAttribute('href'));
+        console.log('img href', img.dataset.href);
         console.log('img data-sizex', img.dataset.sizex);
 
         var img1 = new Image();
-        img1.src = img.getAttribute('href');
-        //drawing of the test image - img1
+        img1.src = img.dataset.href;
         img1.onload = function () {
-          //draw background image
           ctx.drawImage(img1, 0, 0);
-          console.log(canvas.toDataURL('image/jpeg'));
+          const imgData = canvas.toDataURL('image/jpeg');
+          console.log("imgData", imgData);
+          // Show the image on the page
+          img.setAttribute('href', imgData);
         };
       }
       // Select the image
-      const img = document.querySelector('#my-image');
       var imgs = document.querySelectorAll("#svg image");
       imgs.forEach(function (img) {
-        img.addEventListener('load', function (event) {
-          console.log('image loaded...', event.currentTarget)
-          const dataUrl = getDataUrl(event.currentTarget);
-          console.log(dataUrl);
-        });
+        getDataUrl(img);
       });
     }
 
     function downloadFigureSvg() {
-      const figureSvg = createFigureSvg();
+      let figureSvg = svgContainer.innerHTML;
+      // Seems that we need xlink:href for valid svg, but setAttribute('xlink:href', data) doesn't work
+      figureSvg = figureSvg.replaceAll(" href=", " xlink:href=");
       const fileName = (figure_json.figureName || "testFigure") + ".svg";
       downloadString(figureSvg, "text/svg", fileName);
-      alert("Downloaded " + fileName);
     }
 
     // On Page loads....

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -30,6 +30,8 @@ urlpatterns = [
     url(r'^open/$', views.index, name='open_figure'),
     url(r'^file/(?P<file_id>[0-9]+)/$', views.index, name='load_figure'),
 
+    url(r'^svg/(?P<file_id>[0-9]+)/$', views.figure_to_svg, name='figure_to_svg'),
+
     url(r'^imgData/(?P<image_id>[0-9]+)/$', views.img_data_json,
         name='figure_imgData'),
 

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -30,7 +30,8 @@ urlpatterns = [
     url(r'^open/$', views.index, name='open_figure'),
     url(r'^file/(?P<file_id>[0-9]+)/$', views.index, name='load_figure'),
 
-    url(r'^svg/(?P<file_id>[0-9]+)/$', views.figure_to_svg, name='figure_to_svg'),
+    url(r'^svg/(?P<file_id>[0-9]+)/$', views.figure_to_svg,
+        name='figure_to_svg'),
 
     url(r'^imgData/(?P<image_id>[0-9]+)/$', views.img_data_json,
         name='figure_imgData'),

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -76,6 +76,11 @@ def get_length_units():
 
 
 @login_required()
+def figure_to_svg(request, file_id=None, conn=None, **kwargs):
+    return render(request, "figure/svg_test.html", {"file_id": file_id})
+
+
+@login_required()
 def index(request, file_id=None, conn=None, **kwargs):
     """
     Single page 'app' for creating a Figure, allowing you to choose images


### PR DESCRIPTION
This is an investigation into the feasibility of using `svg` file as a new OMERO.figure file format (see #438).

Aims to test:
 - 1 Generation of svg in JavaScript, starting with an existing OMERO.figure json file.
 - 2 Download of that svg from the browser (with embedded images).
 - 3 Opening of that svg in a browser
 - 4 Opening of the svg in another app (e.g. Inkscape or Adobe Illustrator).
 - 5 Eventually, reading that svg in JavaScript to return to the OMERO.figure json (or a JavaScript model equivalent to the existing Backbone `figureModel` that can be updated in the OMERO.figure app).
 
To test, save a figure, then replace `/file/` with `/svg/` in the URL (see screenshot).
This gives a page showing the SVG and a button to download. 
Currently, lots of the svg generation is not done, and things look different in the browser vv Inkscape but in principal it works.

![Screenshot 2021-06-21 at 13 25 47](https://user-images.githubusercontent.com/900055/122762964-c14de600-d295-11eb-9bec-4471b07c4650.png)
