### PR TITLE
chgrp scripts

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
+++ b/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
@@ -1,0 +1,179 @@
+
+import argparse
+import json
+from io import BytesIO
+
+from omero.gateway import BlitzGateway
+from omero.model import FileAnnotationI, OriginalFileI
+from omero.rtypes import wrap, rstring, rlong
+import omero.scripts as scripts
+
+# For each Panel in a Figure (File Annotation ID) find an Image with the same
+# name is the Dataset (ID), replace the ID in the figure JSON.
+# Then save as a new Figure (in the same group as the Images)
+# Usage: python Dataset_Images_To_New_Figure.py DATASET_ID FIGURE_ID
+
+JSON_FILEANN_NS = "omero.web.figure.json"
+
+def save_web_figure(conn, json_data):
+    """
+    Saves 'figureJSON' in POST as an original file. If 'fileId' is specified
+    in POST, then we update that file. Otherwise create a new one with
+    name 'figureName' from POST.
+    """
+    image_ids = []
+    first_img_id = None
+    try:
+        for panel in json_data['panels']:
+            image_ids.append(panel['imageId'])
+        if len(image_ids) > 0:
+            first_img_id = int(image_ids[0])
+        # remove duplicates
+        image_ids = list(set(image_ids))
+        # pretty-print json
+        figure_json = json.dumps(json_data, sort_keys=True,
+                                 indent=2, separators=(',', ': '))
+    except Exception:
+        pass
+
+    # See https://github.com/will-moore/figure/issues/16
+    figure_json = figure_json.encode('utf8')
+
+    if 'figureName' in json_data and len(json_data['figureName']) > 0:
+        figure_name = json_data['figureName']
+    else:
+        print("No figure name found")
+        return
+
+    # we store json in description field...
+    description = {}
+    if first_img_id is not None:
+        # We duplicate the figure name here for quicker access when
+        # listing files
+        # (use this instead of file name because it supports unicode)
+        description['name'] = figure_name
+        description['imageId'] = first_img_id
+        if 'baseUrl' in panel:
+            description['baseUrl'] = panel['baseUrl']
+    desc = json.dumps(description)
+
+    # Create new file
+    # Try to set Group context to the same as first image
+    curr_gid = conn.SERVICE_OPTS.getOmeroGroup()
+    i = None
+    if first_img_id:
+        i = conn.getObject("Image", first_img_id)
+    if i is not None:
+        gid = i.getDetails().getGroup().getId()
+        conn.SERVICE_OPTS.setOmeroGroup(gid)
+    else:
+        # Don't leave as -1
+        conn.SERVICE_OPTS.setOmeroGroup(curr_gid)
+    file_size = len(figure_json)
+    f = BytesIO()
+    f.write(figure_json)
+    orig_file = conn.createOriginalFileFromFileObj(
+        f, '', figure_name, file_size, mimetype="application/json")
+    fa = FileAnnotationI()
+    fa.setFile(OriginalFileI(orig_file.getId(), False))
+    fa.setNs(wrap(JSON_FILEANN_NS))
+    fa.setDescription(wrap(desc))
+
+    update = conn.getUpdateService()
+    fa = update.saveAndReturnObject(fa, conn.SERVICE_OPTS)
+    ann_id = fa.getId().getValue()
+    return ann_id
+
+
+def dataset_images_to_new_figure(conn, params):
+    figure_ids = params["Figure_IDs"]
+    dataset_id = params["IDs"][0]    
+
+    # Get Images by Name from Dataset
+    dataset = conn.getObject("Dataset", dataset_id)
+    images_by_name = {}
+    duplicate_names = []
+    for image in dataset.listChildren():
+        if image.name in images_by_name:
+            duplicate_names.append(image.name)
+        else:
+            images_by_name[image.name] = image.id
+    print("images_by_name", images_by_name)
+    if len(duplicate_names) > 0:
+        print("Multiple images with these names: %s" % duplicate_names)
+        print("Can't identify these images by name")
+
+    ann_ids = []
+    failed_to_replace = 0
+    for figure_id in figure_ids:
+        conn.SERVICE_OPTS.setOmeroGroup(-1)
+        file_ann = conn.getObject("FileAnnotation", figure_id)
+        if file_ann is None:
+            print("Figure File-Annotation %s not found" % figure_id)
+            continue
+        figure_json = b"".join(list(file_ann.getFileInChunks()))
+        figure_json = figure_json.decode('utf8')
+        json_data = json.loads(figure_json)
+        print("Processing figure", figure_id)
+
+        # For each panel, get the name and update the ID
+        for p in json_data.get("panels"):
+            name = p['name']
+            if name in duplicate_names:
+                print("Multiple images with name: %s. NOT replaced" % name)
+                failed_to_replace += 1
+                continue
+            if name not in images_by_name:
+                print("Could not find Image %s. NOT replaced" % name)
+                failed_to_replace += 1
+                continue
+            new_id = images_by_name[name]
+            p["imageId"] = new_id
+
+        # Save new Figure, in the appropriate group
+        ann_ids.append(save_web_figure(conn, json_data))
+
+    msg = "Created %s new Figure%s" % (len(ann_ids), "s" if len(ann_ids) else "")
+    if failed_to_replace:
+        print("Failed to replace %s images" % failed_to_replace)
+        msg += ". See info for warnings"
+    return msg
+
+
+def run_script():
+    """
+    The main entry point of the script, as called by the client
+    via the scripting service, passing the required parameters.
+    """
+
+    client = scripts.client(
+        'Dataset_Images_To_New_Figure.py',
+        """Use Images from a Dataset to replace those in a Figure and
+        save the result as a new Figure, in the same group as the Images""",
+
+        scripts.String(
+            "Data_Type", optional=False, grouping="1",
+            description="Only support Dataset", values=[rstring("Dataset")],
+            default="Dataset"),
+
+        scripts.List(
+            "IDs", optional=False, grouping="2",
+            description="Dataset ID. Only 1 supported").ofType(rlong(0)),
+
+        scripts.List("Figure_IDs", optional=False, grouping="3",
+                     description="Figure ID").ofType(rlong(0)),
+    )
+
+    try:
+        conn = BlitzGateway(client_obj=client)
+        params = client.getInputs(unwrap=True)
+
+        msg = dataset_images_to_new_figure(conn, params)
+        client.setOutput("Message", rstring(msg))
+
+    finally:
+        client.closeSession()
+
+
+if __name__ == "__main__":
+    run_script()

--- a/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
+++ b/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
@@ -89,6 +89,9 @@ def dataset_images_to_new_figure(conn, params):
     figure_ids = params["Figure_IDs"]
     dataset_id = params["IDs"][0]
 
+    if len(figure_ids) == 0:
+        return "Enter Figure IDs separated with a comma: '1,2'"
+
     # Get Images by Name from Dataset
     dataset = conn.getObject("Dataset", dataset_id)
     images_by_name = {}
@@ -133,11 +136,13 @@ def dataset_images_to_new_figure(conn, params):
         # Save new Figure, in the appropriate group
         ann_ids.append(save_web_figure(conn, json_data))
 
+    if len(ann_ids) == 0:
+        return "No figures created. See Info log"
     msg = "Created %s new Figure%s" % (len(ann_ids),
                                        "s" if len(ann_ids) else "")
     if failed_to_replace:
         print("Failed to replace %s images" % failed_to_replace)
-        msg += ". See info for warnings"
+        msg += ". See Info for warnings"
     return msg
 
 
@@ -168,6 +173,7 @@ def run_script():
     try:
         conn = BlitzGateway(client_obj=client)
         params = client.getInputs(unwrap=True)
+        print("params", params)
 
         msg = dataset_images_to_new_figure(conn, params)
         client.setOutput("Message", rstring(msg))

--- a/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
+++ b/omero_figure/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
@@ -1,5 +1,4 @@
 
-import argparse
 import json
 from io import BytesIO
 
@@ -14,6 +13,7 @@ import omero.scripts as scripts
 # Usage: python Dataset_Images_To_New_Figure.py DATASET_ID FIGURE_ID
 
 JSON_FILEANN_NS = "omero.web.figure.json"
+
 
 def save_web_figure(conn, json_data):
     """
@@ -87,7 +87,7 @@ def save_web_figure(conn, json_data):
 
 def dataset_images_to_new_figure(conn, params):
     figure_ids = params["Figure_IDs"]
-    dataset_id = params["IDs"][0]    
+    dataset_id = params["IDs"][0]
 
     # Get Images by Name from Dataset
     dataset = conn.getObject("Dataset", dataset_id)
@@ -133,7 +133,8 @@ def dataset_images_to_new_figure(conn, params):
         # Save new Figure, in the appropriate group
         ann_ids.append(save_web_figure(conn, json_data))
 
-    msg = "Created %s new Figure%s" % (len(ann_ids), "s" if len(ann_ids) else "")
+    msg = "Created %s new Figure%s" % (len(ann_ids),
+                                       "s" if len(ann_ids) else "")
     if failed_to_replace:
         print("Failed to replace %s images" % failed_to_replace)
         msg += ". See info for warnings"

--- a/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
@@ -8,6 +8,7 @@ from omero.rtypes import rstring, rlong, robject
 
 # For an Figure (File Annotation ID) add all Images to a Dataset
 
+
 def images_to_dataset(conn, params):
     figure_ids = params["Figure_IDs"]
     dataset_id = params["IDs"][0]
@@ -17,7 +18,7 @@ def images_to_dataset(conn, params):
         return "Dataset %s not found" % dataset_id, dataset
 
     gid = dataset.getDetails().group.id.val
-    print("Dataset: %s, Group: %s", (dataset.name, gid))    
+    print("Dataset: %s, Group: %s", (dataset.name, gid))
 
     update = conn.getUpdateService()
     conn.SERVICE_OPTS.setOmeroGroup(-1)
@@ -48,8 +49,10 @@ def images_to_dataset(conn, params):
         try:
             update.saveObject(link, conn.SERVICE_OPTS)
             added_count += 1
-        except:
-            print("Failed to link Image %s to Dataset. Link exists or permissions failed" % image_id)
+        except Exception:
+            print("Image %s not linked to Dataset. "
+                  "Link exists or permissions failed"
+                  % image_id)
     return "Added %s images to Dataset" % added_count, dataset
 
 
@@ -72,7 +75,7 @@ def run_script():
         scripts.List(
             "IDs", optional=False, grouping="3",
             description="Dataset ID. Only 1 supported").ofType(rlong(0)),
-        
+
         scripts.List("Figure_IDs", optional=False, grouping="1",
                      description="Figure IDs").ofType(rlong(0)),
     )
@@ -83,7 +86,7 @@ def run_script():
 
         msg, dataset = images_to_dataset(conn, params)
         client.setOutput("Message", rstring(msg))
-        
+
         if dataset is not None:
             client.setOutput("Dataset", robject(dataset._obj))
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
@@ -18,11 +18,13 @@ def images_to_dataset(conn, params):
         return "Dataset %s not found" % dataset_id, dataset
 
     gid = dataset.getDetails().group.id.val
-    print("Dataset: %s, Group: %s", (dataset.name, gid))
+    print("Dataset: %s, Group: %s" % (dataset.name, gid))
 
     update = conn.getUpdateService()
     conn.SERVICE_OPTS.setOmeroGroup(-1)
 
+    if len(figure_ids) == 0:
+        return "Enter Figure IDs separated with a comma: '1,2'", dataset
     image_ids = []
     for figure_id in figure_ids:
         file_ann = conn.getObject("FileAnnotation", figure_id)
@@ -36,7 +38,7 @@ def images_to_dataset(conn, params):
 
     image_ids = list(set(image_ids))
     if len(image_ids) == 0:
-        return "No Images found", dataset
+        return "No Images found. Check Info log", dataset
     print("Image IDs: %s" % image_ids)
 
     conn.SERVICE_OPTS.setOmeroGroup(gid)
@@ -83,6 +85,7 @@ def run_script():
     try:
         conn = BlitzGateway(client_obj=client)
         params = client.getInputs(unwrap=True)
+        print("params", params)
 
         msg, dataset = images_to_dataset(conn, params)
         client.setOutput("Message", rstring(msg))

--- a/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
@@ -1,0 +1,95 @@
+
+import json
+
+import omero.scripts as scripts
+from omero.gateway import BlitzGateway
+from omero.model import DatasetImageLinkI, DatasetI, ImageI
+from omero.rtypes import rstring, rlong, robject
+
+# For an Figure (File Annotation ID) add all Images to a Dataset
+
+def images_to_dataset(conn, params):
+    figure_ids = params["Figure_IDs"]
+    dataset_id = params["IDs"][0]
+
+    dataset = conn.getObject("Dataset", dataset_id)
+    if dataset is None:
+        return "Dataset %s not found" % dataset_id, dataset
+
+    gid = dataset.getDetails().group.id.val
+    print("Dataset: %s, Group: %s", (dataset.name, gid))    
+
+    update = conn.getUpdateService()
+    conn.SERVICE_OPTS.setOmeroGroup(-1)
+
+    image_ids = []
+    for figure_id in figure_ids:
+        file_ann = conn.getObject("FileAnnotation", figure_id)
+        if file_ann is None:
+            print("Figure File-Annotation %s not found" % figure_id)
+        figure_json = b"".join(list(file_ann.getFileInChunks()))
+        figure_json = figure_json.decode('utf8')
+        json_data = json.loads(figure_json)
+
+        image_ids.extend([p["imageId"] for p in json_data.get("panels")])
+
+    image_ids = list(set(image_ids))
+    if len(image_ids) == 0:
+        return "No Images found", dataset
+    print("Image IDs: %s" % image_ids)
+
+    conn.SERVICE_OPTS.setOmeroGroup(gid)
+
+    added_count = 0
+    for image_id in image_ids:
+        link = DatasetImageLinkI()
+        link.parent = DatasetI(dataset_id, False)
+        link.child = ImageI(image_id, False)
+        try:
+            update.saveObject(link, conn.SERVICE_OPTS)
+            added_count += 1
+        except:
+            print("Failed to link Image %s to Dataset. Link exists or permissions failed" % image_id)
+    return "Added %s images to Dataset" % added_count, dataset
+
+
+def run_script():
+    """
+    The main entry point of the script, as called by the client
+    via the scripting service, passing the required parameters.
+    """
+
+    client = scripts.client(
+        'Figure_Images_To_Dataset.py',
+        """Add all Images from one or more Figure(s) into the specified Dataset.
+        (this does not remove the Images from any other Datasets)""",
+
+        scripts.String(
+            "Data_Type", optional=False, grouping="2",
+            description="Only support Dataset", values=[rstring("Dataset")],
+            default="Dataset"),
+
+        scripts.List(
+            "IDs", optional=False, grouping="3",
+            description="Dataset ID. Only 1 supported").ofType(rlong(0)),
+        
+        scripts.List("Figure_IDs", optional=False, grouping="1",
+                     description="Figure IDs").ofType(rlong(0)),
+    )
+
+    try:
+        conn = BlitzGateway(client_obj=client)
+        params = client.getInputs(unwrap=True)
+
+        msg, dataset = images_to_dataset(conn, params)
+        client.setOutput("Message", rstring(msg))
+        
+        if dataset is not None:
+            client.setOutput("Dataset", robject(dataset._obj))
+
+    finally:
+        client.closeSession()
+
+
+if __name__ == "__main__":
+    run_script()


### PR DESCRIPTION
This adds 2 scripts to use in a workflow for duplicating Figures into a different group.

# Workflow

 - Make a list of 1 or more Figure ID (File Annotation IDs), e.g. "10,11,12"
 - Create an empty Dataset
 - Select the Dataset and run script "Figure_Images_To_Dataset.py"
 - Enter the Figure IDs (Dataset ID already populated) and run the script
 - Dataset should now contain all the Images that are in the Figure(s)
 - Now duplicate the Dataset `$ omero dupliate Dataset:ID`
 - Then `chgrp` the new duplicated Dataset to the target Group (via cli or webclient UI)
 - Select the duplicated Dataset in the new Group
 - Run the script "Dataset_Images_To_New_Figure.py"
 - Enter the Figure IDs (same as before e.g. "10,11,12") (Dataset ID already populated) and run the script
 - This will create new Figure(s) in the target Group, with each original Image replaced with the duplicated Images in the target Group
 - The Figure `File > Open` dialog will list all Figures and their groups to check success (might need to refresh)
 - If there were duplicate Image names in the Dataset, message says to look in logs which will list those images (these will need to be manually replaced).
 
<img width="406" alt="Screenshot 2021-07-14 at 23 19 27" src="https://user-images.githubusercontent.com/900055/125700478-bcb453a2-7071-4a6b-97b3-7e7ae8b88cee.png">

cc @pwalczysko 
