### PR TITLE
Use 0.01 increment for channel sliders

### DIFF
--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -282,6 +282,7 @@ var ChannelSliderView = Backbone.View.extend({
                     range: true,
                     min: min,
                     max: max,
+                    step: 0.01,
                     values: [startAvg, endAvg],
                     slide: function(event, ui) {
                         $('.ch_start input', $div).val(ui.values[0]);

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -1,4 +1,7 @@
 
+const SLIDER_INCR_CUTOFF = 100;
+// If the max value of a slider is below this, use smaller slider increments
+
 var ChannelSliderView = Backbone.View.extend({
 
     template: JST["src/templates/channel_slider_template.html"],
@@ -242,6 +245,14 @@ var ChannelSliderView = Backbone.View.extend({
                 var endsNotEqual = ends.reduce(allEqualFn, ends[0]) === undefined;
                 var min = mins.reduce(reduceFn(Math.min));
                 var max = maxs.reduce(reduceFn(Math.max));
+                if (max > SLIDER_INCR_CUTOFF) {
+                    // If we have a large range, use integers, otherwise format to 2dp
+                    startAvg = parseInt(startAvg);
+                    endAvg = parseInt(endAvg);
+                } else {
+                    startAvg = startAvg.toFixed(2);
+                    endAvg = endAvg.toFixed(2);
+                }
                 var color = colors.reduce(allEqualFn, colors[0]) ? colors[0] : 'ccc';
                 // allEqualFn for booleans will return undefined if not or equal
                 var label = labels.reduce(allEqualFn, labels[0]) ? labels[0] : ' ';
@@ -282,11 +293,13 @@ var ChannelSliderView = Backbone.View.extend({
                     range: true,
                     min: min,
                     max: max,
-                    step: 0.01,
+                    step: (max > SLIDER_INCR_CUTOFF) ? 1 : 0.01,
                     values: [startAvg, endAvg],
                     slide: function(event, ui) {
-                        $('.ch_start input', $div).val(ui.values[0]);
-                        $('.ch_end input', $div).val(ui.values[1]);
+                        let chStart = (max > SLIDER_INCR_CUTOFF) ? ui.values[0] : ui.values[0].toFixed(2);
+                        let chEnd = (max > SLIDER_INCR_CUTOFF) ? ui.values[1] : ui.values[1].toFixed(2);
+                        $('.ch_start input', $div).val(chStart);
+                        $('.ch_end input', $div).val(chEnd);
                     },
                     stop: function(event, ui) {
                         self.models.forEach(function(m) {

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -141,7 +141,7 @@ var ChannelSliderView = Backbone.View.extend({
         var idx = event.target.getAttribute('data-idx'),
             startEnd = event.target.getAttribute('data-window');  // 'start' or 'end'
         idx = parseInt(idx, 10);
-        var value = parseInt(event.target.value, 10);
+        var value = parseFloat(event.target.value, 10);
         if (isNaN(value)) return;
         // Make sure 'start' < 'end' value
         if (event.target.getAttribute('max') && value > event.target.getAttribute('max')){
@@ -236,8 +236,8 @@ var ChannelSliderView = Backbone.View.extend({
                 var actives = chData.map(getActive(chIdx));
                 var labels = chData.map(getLabel(chIdx));
                 // Reduce lists into summary for this channel
-                var startAvg = parseInt(starts.reduce(addFn, 0) / starts.length, 10);
-                var endAvg = parseInt(ends.reduce(addFn, 0) / ends.length, 10);
+                var startAvg = starts.reduce(addFn, 0) / starts.length;
+                var endAvg = ends.reduce(addFn, 0) / ends.length;
                 var startsNotEqual = starts.reduce(allEqualFn, starts[0]) === undefined;
                 var endsNotEqual = ends.reduce(allEqualFn, ends[0]) === undefined;
                 var min = mins.reduce(reduceFn(Math.min));


### PR DESCRIPTION
Fixes #467.

 To test - see https://merge-ci.openmicroscopy.org/web/figure/file/95252 for example figure and images (user-3)

- Channel sliders should now have an increment of `0.01` allowing greater control, particularly with floating-point images with small ranges
- When you type values into the start/end input fields, they are no-longer forced to be Integers:

![Screenshot 2022-06-10 at 10 59 33](https://user-images.githubusercontent.com/900055/173042035-f20613e0-fb90-44da-a8c1-6a7ae0d3e472.png)

