### PR TITLE
Dev build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM node:4.2
+FROM openmicroscopy/omero-web-standalone:latest
 
-RUN adduser figure
+USER root
+RUN yum -y install npm
 COPY . /home/figure/src
-RUN chown -R figure /home/figure/src
-USER figure
+
 WORKDIR /home/figure/src
 
-RUN npm install
-RUN npm install grunt-cli
-RUN $(npm bin)/grunt demo
+RUN npm install -g grunt-cli && npm install grunt --save-dev
+RUN $(npm bin)/grunt build
+RUN /opt/omero/web/venv3/bin/pip install -e .
 
-WORKDIR /home/figure/src/demo
-CMD ["python", "-m", "SimpleHTTPServer"]
+USER omero-web

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN npm install -g grunt-cli && npm install grunt --save-dev
 RUN $(npm bin)/grunt build
 RUN /opt/omero/web/venv3/bin/pip install -e .
 
+
+RUN echo "config set omero.web.application_server development" >> /opt/omero/web/config/01-default-webapps.omero
+RUN echo "config set omero.web.debug true" >> /opt/omero/web/config/01-default-webapps.omero
 USER omero-web

--- a/README.rst
+++ b/README.rst
@@ -163,38 +163,20 @@ with:
 
 	$ grunt watch
 
-To update the demo figure app at http://figure.openmicroscopy.org/demo/
-we have a grunt task that concats and moves js files into demo/.
-It also replaces Django template tags in index.html and various js code
-fragments with static app code. This is all handled by the grunt task:
+It is also possible to develop figure in docker without installing anything locally.
+The Docker image is built of top of ``openmicroscopy/omero-web-standalone:latest``, so you will have a fully functional
+omero-web environment while developing ``omero-figure``.
 
 ::
 
-    $ grunt demo
+    $ docker build -t figure-devel .
+    $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080 figure-devel
 
-This puts everything into the omero-figure/demo/ directory.
-This can be tested locally via:
-
-::
-
-    $ cd demo/
-    $ python -m SimpleHTTPServer
-
-Go to http://localhost:8000/ to test it.
-This will not install the script and dependencies required to export the figure
-as PDF.
-
-To update the figure.openmicroscopy.org site:
-
-- Copy the demo directory and replace the demo directory in gh-pages-staging branch
-- Commit changes and open PR against ome/gh-pages-staging as described https://github.com/ome/omero-figure/tree/gh-pages-staging
-
-It is also possible to run the demo in docker without installing anything locally:
+or you can mount your local checkout of omero-figure and the code within docker:
 
 ::
+    $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080  -v /PATH_TO_GIT_REPO/omero-figure:/home/figure/src figure-devel
 
-    $ docker build -t figure-demo .
-    $ docker run -ti --rm -p 8000:8000 figure-demo
 
 Release process
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -165,14 +165,21 @@ with:
 
 It is also possible to develop figure in docker without installing anything locally.
 The Docker image is built on top of ``openmicroscopy/omero-web-standalone:latest``, so you will have a fully functional
-omero-web environment while developing ``omero-figure``.
+omero-web environment while developing ``omero-figure``. 
+First build the Docker image:
 
 ::
 
-    $ docker build -t figure-devel .
+   $ docker build -t figure-devel .
+
+
+To develop ``omero-figure`` you can either make all the changes within the Docker container itself by running:
+::
+
+
     $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080 figure-devel
 
-or you can mount your local checkout of omero-figure and the code within docker:
+The preferred option is to mount the repository containing the omero-figure code. Make the changes locally and see the changes in the docker container. To do so, run:
 
 ::
     $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080  -v /PATH_TO_GIT_REPO/omero-figure:/home/figure/src figure-devel
@@ -185,6 +192,7 @@ After starting the container, run ``docker ps`` to find the ID of the container.
    $ docker exec -u 0 -it CONTAINER_ID bash   # replace CONTAINER_ID by the correct value
    $ cd /home/figure/src
    $ grunt watch
+
 
 
 Release process

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ with:
 	$ grunt watch
 
 It is also possible to develop figure in docker without installing anything locally.
-The Docker image is built of top of ``openmicroscopy/omero-web-standalone:latest``, so you will have a fully functional
+The Docker image is built on top of ``openmicroscopy/omero-web-standalone:latest``, so you will have a fully functional
 omero-web environment while developing ``omero-figure``.
 
 ::
@@ -176,6 +176,15 @@ or you can mount your local checkout of omero-figure and the code within docker:
 
 ::
     $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080  -v /PATH_TO_GIT_REPO/omero-figure:/home/figure/src figure-devel
+
+
+After starting the container, run ``docker ps`` to find the ID of the container. Then run:
+
+::
+
+   $ docker exec -u 0 -it CONTAINER_ID bash   # replace CONTAINER_ID by the correct value
+   $ cd /home/figure/src
+   $ grunt watch
 
 
 Release process

--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,7 @@ The preferred option is to mount the repository containing the omero-figure code
     $ docker run -ti -e OMEROHOST=YOUR_HOST -p 4080:4080  -v /PATH_TO_GIT_REPO/omero-figure:/home/figure/src figure-devel
 
 
-After starting the container, run ``docker ps`` to find the ID of the container. Then run:
+After starting the container, run ``docker ps`` in another terminal to find the ID of the container. Then run:
 
 ::
 


### PR DESCRIPTION
This PR removes the obsolete section about demo 
and revisits the dockerfile so figure can be developed into a "omero-web" docker framework
This work was initiated by discussion on https://forum.image.sc/t/docker-build-error-to-test-omero-figure/68624/5