### PR TITLE
Allow user to choose custom gap size for grid alignment

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -683,7 +683,7 @@ redirect_to:
                     </div>
 
                     <!-- Buttons for Alignment of Panels. see AlignmentToolbarView -->
-                    <div id="alignment-toolbar" class="btn-group icon-buttons">
+                    <div class="btn-group icon-buttons">
                         <button type="button" class="aleft btn btn-default btn-sm" title="Align Left" disabled="disabled">
                             <span class="glyphicon glyphicon-align-left"></span>
                         </button>

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -708,6 +708,24 @@
     .icon-buttons .btn-sm {
         padding: 4px 9px;
     }
+    /* drop-down list uses radio buttons to choose grid gap */
+    /* copies from bootstrap .dropdown-menu li a */
+    .dropdown-menu li label {
+        font-weight: normal;
+        display: block;
+        padding: 3px 20px;
+        white-space: nowrap;
+    }
+    .dropdown-menu li label:hover{
+        color: #ffffff;
+        text-decoration: none;
+        background-color: #428bca;
+    }
+    /* hide radio buttons - show tick icon after checked input */
+    .dropdown-menu input { display: none; }
+    .dropdown-menu input + span { visibility: hidden; }
+    .dropdown-menu input:checked + span { visibility: visible; }
+
     .rotate-font .glyphicon {
         -webkit-transform: rotate(-90deg);
         -moz-transform: rotate(-90deg);

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -785,7 +785,7 @@
                     <!-- Figure Title will be added here -->
                 </div>
 
-                <form class="navbar-form navbar-right">
+                <form id="alignment-toolbars" class="navbar-form navbar-right">
 
                     <!-- Add a New Panel Button -->
                     <div class="btn-group" style="margin-right:20px">
@@ -799,13 +799,32 @@
                     </div>
 
                     <!-- Buttons for Alignment of Panels. see AlignmentToolbarView -->
-                    <div id="alignment-toolbar" class="btn-group icon-buttons">
+                    <div class="btn-group icon-buttons alignment-buttons" style="margin-right: 1px">
                         <button type="button" class="aleft btn btn-default btn-sm" title="Align Left" disabled="disabled">
                             <span class="glyphicon glyphicon-align-left"></span>
                         </button>
                         <button type="button" class="agrid btn btn-default btn-sm" title="Align To Grid" disabled="disabled">
                             <span class="glyphicon glyphicon-th"></span>
                         </button>
+                        <button type="button" class="btn btn-default btn-sm dropdown-toggle" title="Grid spacing options"
+                            data-toggle="dropdown" disabled="disabled" style="padding: 5px 3px">
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                            <li><label><input type="radio" value="auto" checked name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 5% of panel width</label></li>
+                            <li><label><input type="radio" value="0" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 0 px (no gap)</label></li>
+                            <li><label><input type="radio" value="1" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 1 px</label></li>
+                            <li><label><input type="radio" value="2" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 2 px</label></li>
+                            <li><label><input type="radio" value="5" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 5 px</label></li>
+                            <li><label><input type="radio" value="10" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 10 px</label></li>
+                            <li><label><input type="radio" value="15" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 15 px</label></li>
+                            <li><label><input type="radio" value="20" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span> 20 px</label></li>
+                            <li><label><input type="radio" id="custom_grid_gap" value="" name="grid_gap"/><span class="glyphicon glyphicon-ok"> </span>
+                                custom <span id="custom_grid_gap_label"></span>
+                            </label></li>
+                        </ul>
+                    </div>
+                    <div class="btn-group icon-buttons alignment-buttons">
                         <button type="button" class="atop btn btn-default btn-sm rotate-font" title="Align Top" disabled="disabled">
                             <span class="glyphicon glyphicon-align-right"></span>
                         </button>

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -567,7 +567,7 @@
             });
         },
 
-        align_grid: function() {
+        align_grid: function(gridGap) {
             var sel = this.getSelected(),
                 top_left = this.get_top_left_panel(sel),
                 top_x = top_left.get('x'),
@@ -594,8 +594,11 @@
                 }
             }
 
-            var spacer = top_left.get('width')/20,
-                new_x = top_x,
+            var spacer = top_left.get('width')/20;
+            if (!isNaN(parseFloat(gridGap))) {
+                spacer = parseFloat(gridGap);
+            }
+            var new_x = top_x,
                 new_y = top_y,
                 max_h = 0;
             for (var r=0; r<grid.length; r++) {

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -859,7 +859,7 @@
 
     var AlignmentToolbarView = Backbone.View.extend({
 
-        el: $("#alignment-toolbar"),
+        el: $("#alignment-toolbars"),
 
         model:FigureModel,
 
@@ -872,11 +872,13 @@
             "click .aheight": "align_height",
             "click .asize": "align_size",
             "click .amagnification": "align_magnification",
+
+            "click #custom_grid_gap": "custom_grid_gap",
         },
 
         initialize: function() {
             this.listenTo(this.model, 'change:selection', this.render);
-            this.$buttons = $("button", this.$el);
+            this.$buttons = $(".alignment-buttons button", this.$el);
         },
 
         align_left: function(event) {
@@ -886,7 +888,8 @@
 
         align_grid: function(event) {
             event.preventDefault();
-            this.model.align_grid();
+            let gridGap = document.querySelector('input[name="grid_gap"]:checked').value;
+            this.model.align_grid(gridGap);
         },
 
         align_width: function(event) {
@@ -912,6 +915,21 @@
         align_top: function(event) {
             event.preventDefault();
             this.model.align_top();
+        },
+
+        custom_grid_gap: function() {
+            let current = $("#custom_grid_gap").attr("value");
+            // simple propmt to ask user for custom grid gap
+            let gridGap = prompt("Enter grid gap in pixels:", current);
+            gridGap = parseFloat(gridGap);
+            if (isNaN(gridGap)) {
+                alert("Please enter a valid number (of pixels)")
+                return;
+            }
+            // this value will get picked up as radio grid_gap value
+            $("#custom_grid_gap").attr("value", gridGap);
+            // Show the value in the drop-down menu
+            $("#custom_grid_gap_label").text("(" + gridGap + " px)");
         },
 
         render: function() {


### PR DESCRIPTION
Fixes #368 

Also see https://forum.image.sc/t/spacing-between-images-in-omero-figure/68161

To test:

- select some images to align to grid
- In the drop-down beside the grid button, choose a grid gap size in pixels or choose 'custom' size
- If custom size is chosen, prompt asks for user input of size - only numbers are accepted
- Now, when the align-to-grid button is clicked, the panels will align with the chosen gap between them
- The default option "5% of panel width" is the current behaviour and can be chosen again if desired

![Screenshot 2022-07-06 at 15 16 16](https://user-images.githubusercontent.com/900055/177572413-6ca595b7-8ff6-48bb-ad74-5e53501a0409.png)

