### PR TITLE
Dynamic labels with regex

### DIFF
--- a/docs/figure_file_format.rst
+++ b/docs/figure_file_format.rst
@@ -36,7 +36,7 @@ This is an example of a minimal OMERO.figure JSON file::
 
     {
     // see older versions below
-    "version": 5,
+    "version": 6,
     "panels": [
         {
             // position of the panel on the page
@@ -82,6 +82,11 @@ Optional settings for each panel::
     // options are omero.model.LengthI.SYMBOLS.keys()
     "pixel_size_x_unit": 'MICROMETER',
 
+    // pixel size z to show z position in labels
+    "pixel_size_z": 0.32,
+    "pixel_size_z_symbol": 'µm',    // µm by default
+    "pixel_size_z_unit": 'MICROMETER',
+
     // show a scalebar
     "scalebar": {
         "show": true,
@@ -108,11 +113,21 @@ Optional settings for each panel::
             "color": "00FF00"
         },
         {
-            // 'live' timestamps, 'time' one of: index (show 1-based T index), milliseconds,
+            // Dynamic properties: text in labels in the form '[property.format]'
+            // are dynamically replaced by the specified values
+
+            // for 'time' property, 'format' one of: index (show 1-based T index), milliseconds,
             // secs, mins:secs, mins, hrs:mins, hrs:mins:secs,
-            "time": "milliseconds",
+            "text": "[time.milliseconds]",
             "size": "12",
             "position": "topleft",
+            "color": "FFFFFF"
+        },
+        {
+            // for 'x' and 'y' property, 'format' one of: pixel, unit
+            "text": "X: [x.pixel] - Y: [y.pixel]",
+            "size": "12",
+            "position": "topright",
             "color": "FFFFFF"
         }
     ],
@@ -137,6 +152,8 @@ Optional settings for each panel::
 
     // panel rotation in degrees clockwise
     rotation: 0,
+    // rotation symbol to display in label
+    rotation_symbol:'°',
 
 
 Optional settings for the top-level figure object. If not specified,
@@ -207,6 +224,11 @@ that lines will not appear thicker on a panel when it is zoomed in. Supported Sh
 
 Version history
 ----------------
+
+New in version 6:
+
+- 'label': 'time':'seconds' changed to 'text':'[time.seconds]' (for all timestamp formats)
+- 'panel': z pixel properties added ('pixel_size_z', 'pixel_size_z_symbol', 'pixel_size_z_unit')
 
 New in version 5:
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1110,7 +1110,7 @@ class FigureExport(object):
             m = (delta_t % 3600) // 60
             s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
-        else: # Format unknown
+        else:  # Format unknown
             return ""
         if text in ["0 s", "0:00", "0 mins", "0:00:00"]:
             is_negative = False

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1110,6 +1110,8 @@ class FigureExport(object):
             m = (delta_t % 3600) // 60
             s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
+        else: # Format unknown
+            return ""
         if text in ["0 s", "0:00", "0 mins", "0:00:00"]:
             is_negative = False
         return ('-' if is_negative else '') + text
@@ -1166,8 +1168,11 @@ class FigureExport(object):
                     timestamps = panel.get('deltaT')
                     if expr[1] == "index":
                         label_value = str(the_t + 1)
-                    elif timestamps and the_t < len(timestamps):
-                        d_t = timestamps[the_t]
+                    else:
+                        if timestamps and the_t < len(timestamps):
+                            d_t = timestamps[the_t]
+                        else:
+                            d_t = 0
                         label_value = self.get_time_label_text(d_t, expr[1])
 
                 elif expr[0] == "name":

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1166,8 +1166,8 @@ class FigureExport(object):
                     timestamps = panel.get('deltaT')
                     if expr[1] == "index":
                         label_value = str(the_t + 1)
-                    elif timestamps and panel['theT'] < len(timestamps):
-                        d_t = panel['deltaT'][the_t]
+                    elif timestamps and the_t < len(timestamps):
+                        d_t = timestamps[the_t]
                         label_value = self.get_time_label_text(d_t, expr[1])
                         
                 elif expr[0]=="name":
@@ -1189,6 +1189,14 @@ class FigureExport(object):
                     elif expr[1] == "rotation":
                         label_value = panel["rotation"]
                     label_value = str(int(label_value))
+                    
+                elif expr[0]=="depth":
+                    the_z = panel['theZ']
+                    size_z = panel.get('sizeZ')
+                    if expr[1] == "index":
+                        label_value = str(the_z + 1)
+                    elif size_z and the_z < size_z:
+                        label_value = str(round(the_z*panel.get('pixel_size_z'), 2)) + " " + panel.get('pixel_size_x_symbol')
 
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1136,7 +1136,7 @@ class FigureExport(object):
         y = panel['y']
         width = panel['width']
         height = panel['height']
-        
+
         viewport_region = self.get_crop_region(panel)
 
         # Handle page offsets
@@ -1151,7 +1151,7 @@ class FigureExport(object):
                      'topleft': [], 'topright': [],
                      'bottomleft': [], 'bottomright': []}
 
-        parse_re = re.compile("\[.+?\]")
+        parse_re = re.compile(r"\[.+?\]")
         for l in labels:
             # Substitution of special label by their values
             new_text = []
@@ -1160,8 +1160,8 @@ class FigureExport(object):
                 new_text.append(l['text'][last_idx:item.start()])
                 expr = item.group()[1:-1].split("-")
                 label_value = ""
-                
-                if expr[0]=="time":
+
+                if expr[0] == "time":
                     the_t = panel['theT']
                     timestamps = panel.get('deltaT')
                     if expr[1] == "index":
@@ -1169,15 +1169,19 @@ class FigureExport(object):
                     elif timestamps and the_t < len(timestamps):
                         d_t = timestamps[the_t]
                         label_value = self.get_time_label_text(d_t, expr[1])
-                        
-                elif expr[0]=="name":
+
+                elif expr[0] == "name":
                     if expr[1] == "image":
                         label_value = panel['name'].split('/')[-1]
                     elif expr[1] == "dataset":
-                        label_value = panel['datasetName'] if panel['datasetName'] else "No/Many Datasets"
-                    label_value = label_value.replace("_", "\\_") #Escaping for markdown
-                    
-                elif expr[0]=="roi":
+                        if panel['datasetName']:
+                            label_value = panel['datasetName']
+                        else:
+                            label_value = "No/Many Datasets"
+                    # Escaping "_" for markdown
+                    label_value = label_value.replace("_", "\\_")
+
+                elif expr[0] == "roi":
                     if expr[1] == "x":
                         label_value = viewport_region["x"]
                     elif expr[1] == "y":
@@ -1189,19 +1193,22 @@ class FigureExport(object):
                     elif expr[1] == "rotation":
                         label_value = panel["rotation"]
                     label_value = str(int(label_value))
-                    
-                elif expr[0]=="depth":
+
+                elif expr[0] == "depth":
                     the_z = panel['theZ']
                     size_z = panel.get('sizeZ')
                     if expr[1] == "index":
                         label_value = str(the_z + 1)
                     elif size_z and the_z < size_z:
-                        label_value = str(round(the_z*panel.get('pixel_size_z'), 2)) + " " + panel.get('pixel_size_x_symbol')
+                        z_pos = the_z*panel.get('pixel_size_z')
+                        label_value = (str(round(z_pos, 2))
+                                       + " "
+                                       + panel.get('pixel_size_x_symbol'))
 
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()
-            l['text'] = "".join(new_text)
 
+            l['text'] = "".join(new_text)
             pos = l['position']
             l['size'] = int(l['size'])   # make sure 'size' is number
             # If page is black and label is black, make label white

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -30,7 +30,7 @@ from math import atan2, atan, sin, cos, sqrt, radians, floor, ceil
 from copy import deepcopy
 import re
 
-from omero.model import ImageAnnotationLinkI, ImageI, LengthI
+from p.model import ImageAnnotationLinkI, ImageI, LengthI
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 from omero.rtypes import rstring, robject
@@ -1158,6 +1158,7 @@ class FigureExport(object):
                 new_text.append(l['text'][last_idx:item.start()])
                 expr = item.group()[1:-1].split("-")
                 label_value = ""
+                
                 if expr[0]=="time":
                     the_t = panel['theT']
                     timestamps = panel.get('deltaT')
@@ -1166,6 +1167,14 @@ class FigureExport(object):
                     elif timestamps and panel['theT'] < len(timestamps):
                         d_t = panel['deltaT'][the_t]
                         label_value = self.get_time_label_text(d_t, expr[1])
+                        
+                elif expr[0]=="name":
+                    if expr[1] == "image":
+                        label_value = panel['name'].split('/')[-1]
+                    elif expr[1] == "dataset":
+                        label_value = panel['datasetName'] if panel['datasetName'] else "No/Many Datasets"
+                    label_value = label_value.replace("_", "\\_") #Escaping for markdown
+
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()
             l['text'] = "".join(new_text)

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1207,7 +1207,7 @@ class FigureExport(object):
 
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()
-
+            new_text.append(l['text'][last_idx:])
             l['text'] = "".join(new_text)
             pos = l['position']
             l['size'] = int(l['size'])   # make sure 'size' is number

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1225,8 +1225,8 @@ class FigureExport(object):
                             elif format == "unit" and size_z:
                                 z_start = str(round(z_start * pixel_size_z, 2))
                                 z_end = str(round(z_end * pixel_size_z, 2))
-                                label_value = (z_start + "-" + z_end
-                                               + z_symbol)
+                                label_value = (z_start + " " + z_symbol + " - "
+                                               + z_end + " " + z_symbol)
                         else:
                             the_z = panel['theZ'] if panel['theZ'] else 0
                             if format == "pixel":

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1195,12 +1195,15 @@ class FigureExport(object):
                     label_value = str(int(label_value))
 
                 elif expr[0] == "depth":
-                    the_z = panel['theZ']
+                    the_z = panel['theZ'] if panel['theZ'] else 0
                     size_z = panel.get('sizeZ')
+                    pixel_size_z = panel.get('pixel_size_z')
+                    if pixel_size_z is None:
+                        pixel_size_z = 0
                     if expr[1] == "index":
                         label_value = str(the_z + 1)
                     elif size_z and the_z < size_z:
-                        z_pos = the_z*panel.get('pixel_size_z')
+                        z_pos = the_z * pixel_size_z
                         label_value = (str(round(z_pos, 2))
                                        + " "
                                        + panel.get('pixel_size_x_symbol'))

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1093,18 +1093,24 @@ class FigureExport(object):
         is_negative = delta_t < 0
         delta_t = abs(delta_t)
         text = "%d s" % int(round(delta_t))
-        h = int(delta_t // 3600)
-        m = (delta_t % 3600) // 60
-        s = round(delta_t % 60)
         if format in ["milliseconds", "ms"]:
             text = "%s ms" % int(round(delta_t * 1000))
+        elif format in ["secs", "seconds", "s"]:
+            text = "%d s" % int(round(delta_t))
         elif format in ["mins", "minutes", "m"]:
             text = "%s mins" % int(round(delta_t / 60))
         elif format in ["mins:secs", "m:s"]:
+            m = int(delta_t // 60)
+            s = round(delta_t % 60)
             text = "%s:%02d" % (m, s)
         elif format in ["hrs:mins", "h:m"]:
+            h = int(delta_t // 3600)
+            m = int(round((delta_t % 3600) / 60))
             text = "%s:%02d" % (h, m)
         elif format in ["hrs:mins:secs", "h:m:s"]:
+            h = int(delta_t // 3600)
+            m = (delta_t % 3600) // 60
+            s = round(delta_t % 60)
             text = "%s:%02d:%02d" % (h, m, s)
         else:  # Format unknown
             return ""
@@ -1223,8 +1229,8 @@ class FigureExport(object):
                                 label_value = (str(z_start + 1) + "-"
                                                + str(z_end + 1))
                             elif format == "unit" and size_z:
-                                z_start = str(round(z_start * pixel_size_z, 2))
-                                z_end = str(round(z_end * pixel_size_z, 2))
+                                z_start = f"{(z_start * pixel_size_z):.2f}"
+                                z_end = f"{(z_end * pixel_size_z):.2f}"
                                 label_value = (z_start + " " + z_symbol + " - "
                                                + z_end + " " + z_symbol)
                         else:
@@ -1233,9 +1239,8 @@ class FigureExport(object):
                                 label_value = str(the_z + 1)
                             elif (format == "unit" and size_z
                                   and the_z < size_z):
-                                z_pos = the_z * pixel_size_z
-                                label_value = (str(round(z_pos, 2))
-                                               + " " + z_symbol)
+                                z_pos = f"{(the_z * pixel_size_z):.2f}"
+                                label_value = (z_pos + " " + z_symbol)
 
                     elif prop == "rotation":
                         label_value = (str(int(panel["rotation"]))
@@ -1248,9 +1253,9 @@ class FigureExport(object):
                         elif format == "unit":
                             if prop in ['x', 'width']:
                                 scale = panel['pixel_size_x']
-                            else:
+                            elif prop in ['y', 'height']:
                                 scale = panel['pixel_size_y']
-                            rounded = str(round((value * scale), 3))
+                            rounded = f"{(value * scale):.2f}"
                             label_value = ("" + rounded +
                                            " " + panel['pixel_size_x_symbol'])
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -30,7 +30,7 @@ from math import atan2, atan, sin, cos, sqrt, radians, floor, ceil
 from copy import deepcopy
 import re
 
-from p.model import ImageAnnotationLinkI, ImageI, LengthI
+from omero.model import ImageAnnotationLinkI, ImageI, LengthI
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 from omero.rtypes import rstring, robject

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1210,18 +1210,32 @@ class FigureExport(object):
                         prop = "rotation"
 
                     if prop == "z":
-                        the_z = panel['theZ'] if panel['theZ'] else 0
                         size_z = panel.get('sizeZ')
                         pixel_size_z = panel.get('pixel_size_z')
+                        z_symbol = panel.get('pixel_size_z_symbol')
                         if pixel_size_z is None:
                             pixel_size_z = 0
-                        if format == "pixel":
-                            label_value = str(the_z + 1)
-                        elif format == "unit" and size_z and the_z < size_z:
-                            z_pos = the_z * pixel_size_z
-                            label_value = (str(round(z_pos, 2))
-                                           + " "
-                                           + panel.get('pixel_size_z_symbol'))
+
+                        if ("z_projection" in panel.keys()
+                           and panel["z_projection"]):
+                            z_start, z_end = panel["z_start"], panel["z_end"]
+                            if format == "pixel":
+                                label_value = (str(z_start + 1) + "-"
+                                               + str(z_end + 1))
+                            elif format == "unit" and size_z:
+                                z_start = str(round(z_start * pixel_size_z, 2))
+                                z_end = str(round(z_end * pixel_size_z, 2))
+                                label_value = (z_start + "-" + z_end
+                                               + z_symbol)
+                        else:
+                            the_z = panel['theZ'] if panel['theZ'] else 0
+                            if format == "pixel":
+                                label_value = str(the_z + 1)
+                            elif (format == "unit" and size_z
+                                  and the_z < size_z):
+                                z_pos = the_z * pixel_size_z
+                                label_value = (str(round(z_pos, 2))
+                                               + " " + z_symbol)
 
                     elif prop == "rotation":
                         label_value = (str(int(panel["rotation"]))

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1136,6 +1136,8 @@ class FigureExport(object):
         y = panel['y']
         width = panel['width']
         height = panel['height']
+        
+        viewport_region = self.get_crop_region(panel)
 
         # Handle page offsets
         x = x - page['x']
@@ -1174,6 +1176,19 @@ class FigureExport(object):
                     elif expr[1] == "dataset":
                         label_value = panel['datasetName'] if panel['datasetName'] else "No/Many Datasets"
                     label_value = label_value.replace("_", "\\_") #Escaping for markdown
+                    
+                elif expr[0]=="roi":
+                    if expr[1] == "x":
+                        label_value = viewport_region["x"]
+                    elif expr[1] == "y":
+                        label_value = viewport_region["y"]
+                    elif expr[1] == "width":
+                        label_value = viewport_region["width"]
+                    elif expr[1] == "height":
+                        label_value = viewport_region["height"]
+                    elif expr[1] == "rotation":
+                        label_value = panel["rotation"]
+                    label_value = str(int(label_value))
 
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1208,8 +1208,16 @@ class FigureExport(object):
                                        + " "
                                        + panel.get('pixel_size_x_symbol'))
 
+                elif expr[0] == "channels":
+                    label_value = []
+                    for channel in panel["channels"]:
+                        if channel["active"]:
+                            label_value.append(channel["label"])
+                    label_value = " ".join(label_value)
+
                 new_text.append(label_value if label_value else item.group())
                 last_idx += item.end()
+
             new_text.append(l['text'][last_idx:])
             l['text'] = "".join(new_text)
             pos = l['position']

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -167,27 +167,11 @@
         padding: 3px 15px;
     }
 
-    .markdown-info {
-        padding: 3px 12px;
-        color: #aaa;
-        text-align: right;
-        padding-left: 40px;
-        background: url(../images/markdown_light32x20.png) 0% center no-repeat;
-    }
-    .markdown-info:hover {
-        background: url(../images/markdown_dark32x20.png) 0% center no-repeat;
-    }
     .legend-container .markdown-info {
         display: none;
     }
     .legend-container .editing .markdown-info {
         display: block;
-    }
-
-    #labelsTab .markdown-info {
-        height: 18px;
-        margin: 9px 9px 0;
-        float: left"
     }
 
     /* hide appropriate collapse/hide button */

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -548,13 +548,38 @@
                     </table>
                     <h4>Dynamic properties</h4>
                     <p>
-                        Certain properties can be inserted in the label and are dynamically updated. For example,
-                        [x.pixel] will be replaced by the x coordinate of the viewport in pixels
-                        and [time.secs] will be replaced by the time in seconds of the current frame (automatically
-                        updated when the displayed frame is changed). Dynamic labels can be combined with
-                        markdown formatting.<br><br>
-                        The accepted syntaxes are <strong>[property]</strong> and <strong>[property.format]</strong>
+                        Certain properties can be inserted in the label and are dynamically updated upon changes.
                     </p>
+                    <table class="table">
+                        <tr>
+                            <td></td>
+                            <th>This text will be formatted to...</th>
+                            <th>...this text</th></tr>
+                        <tr>
+                        <tr>
+                            <th>X and Y in pixels</th>
+                            <td>**X:**[x] **Y:**[y]</td>
+                            <td><strong>X:</strong>56 <strong>Y:</strong>48</td>
+                        </tr>
+                        <tr>
+                            <th>Time in h:m:s format</th>
+                            <td>Time: *[time.h:m:s]*</td>
+                            <td>Time: <i>0:12:53</i></td>
+                        </tr>
+                        <tr>
+                            <th>Z in units (projection toggled OFF)</th>
+                            <td>Z: [z.unit]</td>
+                            <td>Z: 1.52 &#181;m</td>
+                        </tr>
+                        <tr>
+                            <th>Z slice range (projection toggled ON)</th>
+                            <td>Z projection: [z]</td>
+                            <td>Z projection: 15 - 27</td>
+                        </tr>
+                    </table>
+
+                    <p>The accepted syntaxes are <strong>[property]</strong>
+                        and <strong>[property.format]</strong> for the following values:</p>
                     <table class="table">
                         <tr>
                             <td></td>
@@ -562,27 +587,27 @@
                             <th>Format - alias (first is default)</th></tr>
                         <tr>
                         <tr>
-                            <th>Viewport X</th>
+                            <th>View X</th>
                             <td>x</td>
                             <td>pixel - px<br>unit</td>
                         </tr>
                         <tr>
-                            <th>Viewport Y</th>
+                            <th>View Y</th>
                             <td>y</td>
                             <td>pixel - px<br>unit</td>
                         </tr>
                         <tr>
-                            <th>Viewport width</th>
+                            <th>View width</th>
                             <td>width - w</td>
                             <td>pixel - px<br>unit</td>
                         </tr>
                         <tr>
-                            <th>Viewport height</th>
+                            <th>View height</th>
                             <td>height - h</td>
                             <td>pixel - px<br>unit</td>
                         </tr>
                         <tr>
-                            <th>Viewport rotation</th>
+                            <th>View rotation</th>
                             <td>rotation - rot</td>
                             <td></td>
                         </tr>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -514,9 +514,10 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">Markdown Formatting</h4>
+                    <h4 class="modal-title">Label Formatting</h4>
                 </div>
                 <div class="modal-body">
+                    <h4>Markdown formatting</h4>
                     <p>
                         You can use "Markdown" syntax to add formatting to plain text. For example,
                         **this text will be bold** and this *word* will be italic. NB: Links are not
@@ -545,6 +546,73 @@
                         </tr>
                        <!--  <tr><td>You need to use 2 line breaks between paragraphs</td><td></td></tr> -->
                     </table>
+                    <h4>Dynamic properties</h4>
+                    <p>
+                        Certain properties can be inserted in the label and are dynamically updated. For example,
+                        [x.pixel] will be replaced by the x coordinate of the viewport in pixels
+                        and [time.secs] will be replaced by the time in seconds of the current frame (automatically
+                        updated when the displayed frame is changed). Dynamic labels can be combined with
+                        markdown formatting.<br><br>
+                        The accepted syntaxes are <strong>[property]</strong> and <strong>[property.format]</strong>
+                    </p>
+                    <table class="table">
+                        <tr>
+                            <td></td>
+                            <th>Property - alias</th>
+                            <th>Format - alias (first is default)</th></tr>
+                        <tr>
+                        <tr>
+                            <th>Viewport X</th>
+                            <td>x</td>
+                            <td>pixel - px<br>unit</td>
+                        </tr>
+                        <tr>
+                            <th>Viewport Y</th>
+                            <td>y</td>
+                            <td>pixel - px<br>unit</td>
+                        </tr>
+                        <tr>
+                            <th>Viewport width</th>
+                            <td>width - w</td>
+                            <td>pixel - px<br>unit</td>
+                        </tr>
+                        <tr>
+                            <th>Viewport height</th>
+                            <td>height - h</td>
+                            <td>pixel - px<br>unit</td>
+                        </tr>
+                        <tr>
+                            <th>Viewport rotation</th>
+                            <td>rotation - rot</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <th>Z slice</th>
+                            <td>z</td>
+                            <td>pixel - px<br>unit</td>
+                        </tr>
+                        <tr>
+                            <th>Time</th>
+                            <td>time - t</td>
+                            <td>index<br>milliseconds - ms<br>seconds - secs - s<br>minutes - mins - m<br>hrs:mins:secs - h:m:s<br>mins:secs - m:s<br>hrs:mins - h:m</td>
+                        </tr>
+                        <tr>
+                            <th>Active channels</th>
+                            <td>channels - c</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <th>Image identifier</th>
+                            <td>image</td>
+                            <td>name<br>id</td>
+                        </tr>
+                        <tr>
+                            <th>Dataset identifier</th>
+                            <td>dataset</td>
+                            <td>name<br>id</td>
+                        </tr>
+                    </table>
+                    <h4>Legend</h4>
                     <p>The figure legend will be included in the PDF info page when the figure is
                         exported.</p>
                 </div>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -1088,7 +1088,9 @@
                     <h5 style="float: left">Add Labels</h5>
 
                     <button type="button" class="btn btn-link markdown-info"
-                        title="Use Markdown formatting. Click for more info..."></button>
+                        title="Show label formatting options...">
+                        Tips
+                    </button>
                     <div class="clearfix"></div>
                     <form class="new-label-form form-inline" role="form">
                     </form>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -548,8 +548,11 @@
                     </table>
                     <h4>Dynamic properties</h4>
                     <p>
-                        Certain properties can be inserted in the label (within square brackets)
-                        and are dynamically updated upon changes. See the drop-down options for supported properties.
+                        The drop-down menu in the 'Add Labels' form allows you to create labels based on Image metadata. 
+                        Labels created with square brackets indicate dynamic properties. The properties within the square 
+                        brackets will be dynamically updated upon changes. Additional text can be added outside the square 
+                        brackets and will not be affected when the labels are displayed.<br>
+                        The following table shows some examples, including the use of dynamic properties and markdown together.
                     </p>
                     <table class="table">
                         <tr>

--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -516,7 +516,7 @@
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                     <h4 class="modal-title">Label Formatting</h4>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body" style="max-height:518px">
                     <h4>Markdown formatting</h4>
                     <p>
                         You can use "Markdown" syntax to add formatting to plain text. For example,
@@ -548,7 +548,8 @@
                     </table>
                     <h4>Dynamic properties</h4>
                     <p>
-                        Certain properties can be inserted in the label and are dynamically updated upon changes.
+                        Certain properties can be inserted in the label (within square brackets)
+                        and are dynamically updated upon changes. See the drop-down options for supported properties.
                     </p>
                     <table class="table">
                         <tr>
@@ -558,83 +559,33 @@
                         <tr>
                         <tr>
                             <th>X and Y in pixels</th>
-                            <td>**X:**[x] **Y:**[y]</td>
-                            <td><strong>X:</strong>56 <strong>Y:</strong>48</td>
+                            <td>X:[x.pixel] - Y:[y.pixel]</td>
+                            <td>X:52 - Y:89</td>
                         </tr>
                         <tr>
-                            <th>Time in h:m:s format</th>
-                            <td>Time: *[time.h:m:s]*</td>
-                            <td>Time: <i>0:12:53</i></td>
+                            <th>X and Y in units</th>
+                            <td>X:[x.unit] - Y:[y.unit]</td>
+                            <td>X:0.43 &#181;m - Y:0.23 &#181;m</td>
                         </tr>
                         <tr>
-                            <th>Z in units (projection toggled OFF)</th>
-                            <td>Z: [z.unit]</td>
-                            <td>Z: 1.52 &#181;m</td>
+                            <th>Width</th>
+                            <td>Width: [width.pixel]</td>
+                            <td>Width: 400</td>
                         </tr>
                         <tr>
-                            <th>Z slice range (projection toggled ON)</th>
-                            <td>Z projection: [z]</td>
-                            <td>Z projection: 15 - 27</td>
-                        </tr>
-                    </table>
-
-                    <p>The accepted syntaxes are <strong>[property]</strong>
-                        and <strong>[property.format]</strong> for the following values:</p>
-                    <table class="table">
-                        <tr>
-                            <td></td>
-                            <th>Property - alias</th>
-                            <th>Format - alias (first is default)</th></tr>
-                        <tr>
-                        <tr>
-                            <th>View X</th>
-                            <td>x</td>
-                            <td>pixel - px<br>unit</td>
+                            <th>Height (with markdown formatting)</th>
+                            <td>*Height*: **[height.pixel]**</td>
+                            <td><i>Height</i>: <strong>300</strong></td>
                         </tr>
                         <tr>
-                            <th>View Y</th>
-                            <td>y</td>
-                            <td>pixel - px<br>unit</td>
+                            <th>Image ID</th>
+                            <td>Image ID: [image.id]</td>
+                            <td>Image ID: 23556</td>
                         </tr>
                         <tr>
-                            <th>View width</th>
-                            <td>width - w</td>
-                            <td>pixel - px<br>unit</td>
-                        </tr>
-                        <tr>
-                            <th>View height</th>
-                            <td>height - h</td>
-                            <td>pixel - px<br>unit</td>
-                        </tr>
-                        <tr>
-                            <th>View rotation</th>
-                            <td>rotation - rot</td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>Z slice</th>
-                            <td>z</td>
-                            <td>pixel - px<br>unit</td>
-                        </tr>
-                        <tr>
-                            <th>Time</th>
-                            <td>time - t</td>
-                            <td>index<br>milliseconds - ms<br>seconds - secs - s<br>minutes - mins - m<br>hrs:mins:secs - h:m:s<br>mins:secs - m:s<br>hrs:mins - h:m</td>
-                        </tr>
-                        <tr>
-                            <th>Active channels</th>
-                            <td>channels - c</td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>Image identifier</th>
-                            <td>image</td>
-                            <td>name<br>id</td>
-                        </tr>
-                        <tr>
-                            <th>Dataset identifier</th>
-                            <td>dataset</td>
-                            <td>name<br>id</td>
+                            <th>Dataset ID</th>
+                            <td>Dataset ID: [dataset.id]</td>
+                            <td>Dataset ID: 1654</td>
                         </tr>
                     </table>
                     <h4>Legend</h4>

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -73,6 +73,10 @@ urlpatterns = [
     # Use query ?image=1&image=2
     url(r'^timestamps/$', views.timestamps, name='figure_timestamps'),
 
+    # Get Z scale for images
+    # Use query ?image=1&image=2
+    url(r'^z_scale/$', views.z_scale, name='figure_z_scale'),
+
     url(r'^roiCount/(?P<image_id>[0-9]+)/$', views.roi_count,
         name='figure_roiCount'),
 

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -131,9 +131,10 @@ def img_data_json(request, image_id, conn=None, **kwargs):
         rv['pixel_size']['symbolY'] = py.getSymbol()
         rv['pixel_size']['unitY'] = str(py.getUnit())
         pz = image.getPrimaryPixels().getPhysicalSizeZ()
-        rv['pixel_size']['valueZ'] = pz.getValue()
-        rv['pixel_size']['symbolZ'] = pz.getSymbol()
-        rv['pixel_size']['unitZ'] = str(pz.getUnit())
+        if pz is not None:
+            rv['pixel_size']['valueZ'] = pz.getValue()
+            rv['pixel_size']['symbolZ'] = pz.getSymbol()
+            rv['pixel_size']['unitZ'] = str(pz.getUnit())
     size_t = image.getSizeT()
     time_list = []
     if size_t > 1:

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -130,6 +130,10 @@ def img_data_json(request, image_id, conn=None, **kwargs):
         rv['pixel_size']['valueY'] = py.getValue()
         rv['pixel_size']['symbolY'] = py.getSymbol()
         rv['pixel_size']['unitY'] = str(py.getUnit())
+        pz = image.getPrimaryPixels().getPhysicalSizeZ()
+        rv['pixel_size']['valueZ'] = pz.getValue()
+        rv['pixel_size']['symbolZ'] = pz.getSymbol()
+        rv['pixel_size']['unitZ'] = str(pz.getUnit())
     size_t = image.getSizeT()
     time_list = []
     if size_t > 1:

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -157,6 +157,22 @@ def timestamps(request, conn=None, **kwargs):
 
 
 @login_required()
+def z_scale(request, conn=None, **kwargs):
+
+    iids = request.GET.getlist('image')
+    data = {}
+    for iid in iids:
+        image = conn.getObject('Image', iid)
+        if image is not None:
+            pz = image.getPrimaryPixels().getPhysicalSizeZ()
+            if pz is not None:
+                data[image.id] = {'valueZ': pz.getValue(),
+                                  'symbolZ': pz.getSymbol(),
+                                  'unitZ': str(pz.getUnit())}
+    return JsonResponse(data)
+
+
+@login_required()
 def render_scaled_region(request, iid, z, t, conn=None, **kwargs):
 
     region = request.GET.get('region')

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -221,10 +221,10 @@
                     });
                 }
             }
-			
-			if (v < 6) {
-				//Need to update version so that it includes  'pixel_size_z': data.pixel_size.z,
-			}
+
+            if (v < 6) {
+            //Need to update version so that it includes  'pixel_size_z': data.pixel_size.z,
+            }
 
             return json;
         },
@@ -461,9 +461,11 @@
                         'datasetId': data.meta.datasetId,
                         'pixel_size_x': data.pixel_size.valueX,
                         'pixel_size_y': data.pixel_size.valueY,
-						'pixel_size_z': data.pixel_size.z,
+                        'pixel_size_z': data.pixel_size.valueZ,
                         'pixel_size_x_symbol': data.pixel_size.symbolX,
+                        'pixel_size_z_symbol': data.pixel_size.symbolZ,
                         'pixel_size_x_unit': data.pixel_size.unitX,
+                        'pixel_size_z_unit': data.pixel_size.unitZ,
                         'deltaT': data.deltaT,
                     };
                     if (baseUrl) {

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -224,6 +224,7 @@
 
             if (v < 6) {
                 console.log("Transforming to VERSION 6");
+                // Adding the Z scale to the model
                 var iids = [];
                 _.each(json.panels, function(p) {
                     if (iids.indexOf(p.imageId) == -1) {
@@ -246,6 +247,17 @@
                         });
                     });
                 }
+
+                // Converting the time-labels to V6 syntax, all other special label were converted to text
+                _.each(json.panels, function(p) {
+                    for (var i=0; i<p["labels"].length; i++){
+                        label = p["labels"][i];
+                        if (label["time"]) {
+                            label["text"] = "[time."+label["time"]+"]";
+                            delete label.time;
+                        }
+                    }
+                });
             }
 
             return json;

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -223,7 +223,29 @@
             }
 
             if (v < 6) {
-            //Need to update version so that it includes  'pixel_size_z': data.pixel_size.z,
+                console.log("Transforming to VERSION 6");
+                var iids = [];
+                _.each(json.panels, function(p) {
+                    if (iids.indexOf(p.imageId) == -1) {
+                        iids.push(p.imageId)
+                    }
+                });
+                if (iids.length > 0) {
+                    zUrl = BASE_WEBFIGURE_URL + 'z_scale/';
+                    zUrl += '?image=' + iids.join('&image=');
+                    $.getJSON(zUrl, function(data) {
+                        // Update all panels
+                        // NB: By the time that this callback runs, the panels will have been created
+                        self.panels.forEach(function(p){
+                            var iid = p.get('imageId');
+                            if (data[iid]) {
+                                p.set('pixel_size_z', data[iid].valueZ);
+                                p.set('pixel_size_z_symbol', data[iid].symbolZ);
+                                p.set('pixel_size_z_unit', data[iid].unitZ);
+                            }
+                        });
+                    });
+                }
             }
 
             return json;

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -221,7 +221,7 @@
                     });
                 }
             }
-
+            
             if (v < 6) {
                 console.log("Transforming to VERSION 6");
                 // Adding the Z scale to the model

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -1,7 +1,7 @@
     
     // Version of the json file we're saving.
     // This only needs to increment when we make breaking changes (not linked to release versions.)
-    var VERSION = 5;
+    var VERSION = 6;
 
 
     // ------------------------- Figure Model -----------------------------------
@@ -221,6 +221,10 @@
                     });
                 }
             }
+			
+			if (v < 6) {
+				//Need to update version so that it includes  'pixel_size_z': data.pixel_size.z,
+			}
 
             return json;
         },
@@ -457,6 +461,7 @@
                         'datasetId': data.meta.datasetId,
                         'pixel_size_x': data.pixel_size.valueX,
                         'pixel_size_y': data.pixel_size.valueY,
+						'pixel_size_z': data.pixel_size.z,
                         'pixel_size_x_symbol': data.pixel_size.symbolX,
                         'pixel_size_x_unit': data.pixel_size.unitX,
                         'deltaT': data.deltaT,

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -354,11 +354,12 @@
                     start = this.get('z_start');
                     end = this.get('z_end');
                     if (format === "pixel") {
-                        text = "" + (start+1) + "-" + (end+1);
+                        text = "" + (start+1) + " - " + (end+1);
                     } else if (format === "unit"){
                         start = (start * this.get('pixel_size_z')).toPrecision(3)
                         end = (end * this.get('pixel_size_z')).toPrecision(3)
-                        text = ""+ start + "-" + end +" "+ this.get('pixel_size_z_symbol')
+                        text = ""+ start +" "+ this.get('pixel_size_z_symbol')
+                               + " - " + end +" "+ this.get('pixel_size_z_symbol')
                     }
                 }
                 else {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -350,12 +350,26 @@
 
             var text = "";
             if (property === "z") {
-                var theZ = this.get('theZ');
-                if (format === "pixel") {
-                    text = "" + (theZ + 1);
-                } else if (format === "unit"){
-                    text = ""+ (theZ * this.get('pixel_size_z')).toPrecision(3) +" "+ this.get('pixel_size_z_symbol')
+                if (this.get('z_projection')) {
+                    start = this.get('z_start');
+                    end = this.get('z_end');
+                    if (format === "pixel") {
+                        text = "" + (start+1) + "-" + (end+1);
+                    } else if (format === "unit"){
+                        start = (start * this.get('pixel_size_z')).toPrecision(3)
+                        end = (end * this.get('pixel_size_z')).toPrecision(3)
+                        text = ""+ start + "-" + end +" "+ this.get('pixel_size_z_symbol')
+                    }
                 }
+                else {
+                    var theZ = this.get('theZ');
+                    if (format === "pixel") {
+                        text = "" + (theZ + 1);
+                    } else if (format === "unit"){
+                        text = ""+ (theZ * this.get('pixel_size_z')).toPrecision(3) +" "+ this.get('pixel_size_z_symbol')
+                    }
+                }
+
                 return text
             }
             viewport = this.getViewportAsRect();

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -308,6 +308,16 @@
             return (isNegative ? '-' : '') + text;
         },
 
+		get_name_label_text: function(format) {
+            var text = "";
+            if (format === "image") {
+                var pathnames = this.get('name').split('/');
+                text = pathnames[pathnames.length-1];
+            } else if (format === "dataset"){
+                text = this.get('datasetName') ? this.get('datasetName') : "No/Many Datasets";
+            }
+            return text;
+        },
 
         get_label_key: function(label) {
             var key = label.text + '_' + label.size + '_' + label.color + '_' + label.position;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -308,18 +308,9 @@
             return (isNegative ? '-' : '') + text;
         },
 
-        create_labels_from_time: function(options) {
-            
-            this.add_labels([{
-                    'time': options.format,
-                    'size': options.size,
-                    'position': options.position,
-                    'color': options.color
-            }]);
-        },
 
         get_label_key: function(label) {
-            var key = (label.text || label.time) + '_' + label.size + '_' + label.color + '_' + label.position;
+            var key = label.text + '_' + label.size + '_' + label.color + '_' + label.position;
             key = _.escape(key);
             return key;
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -318,6 +318,23 @@
             }
             return text;
         },
+		
+		get_roi_label_text: function(format) {
+			viewport = this.getViewportAsRect();
+            var text = "";
+            if (format === "x") {
+                text = ""+Math.round(viewport['x']);
+            } else if (format === "y"){
+                text = ""+Math.round(viewport['y']);
+            } else if (format === "width"){
+                text = ""+Math.round(viewport['width']);
+            } else if (format === "height"){
+                text = ""+Math.round(viewport['height']);
+            } else if (format === "rotation"){
+                text = ""+Math.round(viewport['rotation']);
+            }
+            return text;
+        },
 
         get_label_key: function(label) {
             var key = label.text + '_' + label.size + '_' + label.color + '_' + label.position;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -265,6 +265,17 @@
             this.add_labels(newLabels);
         },
 
+        get_channels_label_text: function() {
+            var text = "";
+            _.each(this.get('channels'), function(c){
+                if (c.active) {
+                    if (text==="") text = c.label
+                    else text = text + " " + c.label
+                }
+            });
+            return text?text:" ";
+        },
+
         getDeltaT: function() {
             var theT = this.get('theT');
             return this.get('deltaT')[theT] || 0;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -323,15 +323,15 @@
 			viewport = this.getViewportAsRect();
             var text = "";
             if (format === "x") {
-                text = ""+Math.round(viewport['x']);
+                text = ""+parseInt(viewport['x']);
             } else if (format === "y"){
-                text = ""+Math.round(viewport['y']);
+                text = ""+parseInt(viewport['y']);
             } else if (format === "width"){
-                text = ""+Math.round(viewport['width']);
+                text = ""+parseInt(viewport['width']);
             } else if (format === "height"){
-                text = ""+Math.round(viewport['height']);
+                text = ""+parseInt(viewport['height']);
             } else if (format === "rotation"){
-                text = ""+Math.round(viewport['rotation']);
+                text = ""+parseInt(viewport['rotation']);
             }
             return text;
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -369,8 +369,8 @@
                     if (format === "pixel") {
                         text = "" + (start+1) + " - " + (end+1);
                     } else if (format === "unit"){
-                        start = (start * z_size).toPrecision(3)
-                        end = (end * z_size).toPrecision(3)
+                        start = (start * z_size).toFixed(2)
+                        end = (end * z_size).toFixed(2)
                         text = ""+ start +" "+ z_symbol
                                + " - " + end +" "+ z_symbol
                     }
@@ -380,20 +380,20 @@
                     if (format === "pixel") {
                         text = "" + (theZ + 1);
                     } else if (format === "unit"){
-                        text = ""+ (theZ * z_size).toPrecision(3) +" "+ z_symbol
+                        text = ""+ (theZ * z_size).toFixed(2) +" "+ z_symbol
                     }
                 }
                 return text
             }
             viewport = this.getViewportAsRect();
-            value = parseInt(viewport[property]);
+            value = viewport[property];
             if (property === "rotation") {
-                return ""+value+"°";
+                return ""+parseInt(value)+"°";
             } else if (format === "pixel") {
-                return ""+value;
+                return ""+parseInt(value);
             } else if (format === "unit") {
                 scale = ['x', 'width'].includes(property) ? x_size : y_size
-                text = ""+ (value * scale).toPrecision(3) +" "+ x_symbol
+                text = ""+ (value * scale).toFixed(2) +" "+ x_symbol
             }
             return text
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -21,6 +21,7 @@
             selected: false,
             pixel_size_x_symbol: '\xB5m',     // microns by default
             pixel_size_x_unit: 'MICROMETER',
+            rotation_symbol: '\xB0',
             max_export_dpi: 1000,
 
             // 'export_dpi' optional value to resample panel on export

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -313,6 +313,8 @@
                 m = pad(parseInt((deltaT % 3600) / 60));
                 s = pad(Math.round(deltaT % 60));
                 text = h + ":" + m + ":" + s;
+            } else { // Format unknown
+                return ""
             }
             if (["0 s", "0:00", "0 mins", "0:00:00"].indexOf(text) > -1) {
                 isNegative = false;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -295,9 +295,6 @@
                 isNegative = (deltaT < 0),
                 text = "", h, m, s;
             deltaT = Math.abs(deltaT);
-            h = parseInt(deltaT / 3600);
-            m = parseInt(deltaT / 60);
-            s = pad(Math.round(deltaT % 60));
             if (format === "index") {
                 isNegative = false;
                 text = "" + (theT + 1);
@@ -308,10 +305,17 @@
             } else if (['minutes', 'mins', 'm'].includes(format)) {
                 text = Math.round(deltaT / 60) + " mins";
             } else if (["mins:secs", "m:s"].includes(format)) {
+                m = parseInt(deltaT / 60);
+                s = pad(Math.round(deltaT % 60));
                 text = m + ":" + s;
             } else if (["hrs:mins", "h:m"].includes(format)) {
+                h = parseInt(deltaT / 3600);
+                m = pad(Math.round((deltaT % 3600) / 60));
                 text = h + ":" + m;
             } else if (["hrs:mins:secs", "h:m:s"].includes(format)) {
+                h = parseInt(deltaT / 3600);
+                m = pad(parseInt((deltaT % 3600) / 60));
+                s = pad(Math.round(deltaT % 60));
                 text = h + ":" + m + ":" + s;
             } else { // Format unknown
                 return ""

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -348,6 +348,15 @@
             else if (property === "h") property = "height";
             else if (property === "rot") property = "rotation";
 
+            
+            x_symbol = this.get('pixel_size_x_symbol');
+            z_symbol = this.get('pixel_size_z_symbol');
+            z_symbol = z_symbol?z_symbol:x_symbol // Using x symbol when z not defined
+            x_size = this.get('pixel_size_x');
+            y_size = this.get('pixel_size_y');
+            z_size = this.get('pixel_size_z');
+            z_size = z_size?z_size:0
+
             var text = "";
             if (property === "z") {
                 if (this.get('z_projection')) {
@@ -356,10 +365,10 @@
                     if (format === "pixel") {
                         text = "" + (start+1) + " - " + (end+1);
                     } else if (format === "unit"){
-                        start = (start * this.get('pixel_size_z')).toPrecision(3)
-                        end = (end * this.get('pixel_size_z')).toPrecision(3)
-                        text = ""+ start +" "+ this.get('pixel_size_z_symbol')
-                               + " - " + end +" "+ this.get('pixel_size_z_symbol')
+                        start = (start * z_size).toPrecision(3)
+                        end = (end * z_size).toPrecision(3)
+                        text = ""+ start +" "+ z_symbol
+                               + " - " + end +" "+ z_symbol
                     }
                 }
                 else {
@@ -367,10 +376,9 @@
                     if (format === "pixel") {
                         text = "" + (theZ + 1);
                     } else if (format === "unit"){
-                        text = ""+ (theZ * this.get('pixel_size_z')).toPrecision(3) +" "+ this.get('pixel_size_z_symbol')
+                        text = ""+ (theZ * z_size).toPrecision(3) +" "+ z_symbol
                     }
                 }
-
                 return text
             }
             viewport = this.getViewportAsRect();
@@ -380,8 +388,8 @@
             } else if (format === "pixel") {
                 return ""+value;
             } else if (format === "unit") {
-                scale = ['x', 'width'].includes(property) ? this.get('pixel_size_x') : this.get('pixel_size_y')
-                text = ""+ (value * scale).toPrecision(3) +" "+ this.get('pixel_size_x_symbol')
+                scale = ['x', 'width'].includes(property) ? x_size : y_size
+                text = ""+ (value * scale).toPrecision(3) +" "+ x_symbol
             }
             return text
         },

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -96,6 +96,7 @@
                 'datasetName': data.datasetName,
                 'pixel_size_x': data.pixel_size_x,
                 'pixel_size_y': data.pixel_size_y,
+				'pixel_size_z': data.pixel_size_z,
                 'pixel_size_x_symbol': data.pixel_size_x_symbol,
                 'pixel_size_x_unit': data.pixel_size_x_unit,
                 'deltaT': data.deltaT,
@@ -332,6 +333,17 @@
                 text = ""+parseInt(viewport['height']);
             } else if (format === "rotation"){
                 text = ""+parseInt(viewport['rotation']);
+            }
+            return text;
+        },
+		
+		get_depth_label_text: function(format) {
+            var theZ = this.get('theZ');
+            var text = "";
+            if (format === "index") {
+                text = "" + (theZ + 1);
+            } else if (format === "unit"){
+                text = ""+ (theZ * this.get('pixel_size_z')).toPrecision(3) +" "+ this.get('pixel_size_x_symbol')
             }
             return text;
         },

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -22,7 +22,7 @@
                 'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
                 this.render_image);
             this.listenTo(this.model,
-                'change:channels change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ',
+                'change:channels change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ change:z_projection change:z_start change:z_end',
                 this.render_labels);
             this.listenTo(this.model, 'change:shapes', this.render_shapes);
 

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -21,7 +21,7 @@
             this.listenTo(this.model,
                 'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
                 this.render_image);
-            this.listenTo(this.model, 'change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT', this.render_labels);
+            this.listenTo(this.model, 'change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ', this.render_labels);
             this.listenTo(this.model, 'change:shapes', this.render_shapes);
 
             // During drag or resize, model isn't updated, but we trigger 'drag'
@@ -196,14 +196,16 @@
                         var new_text = new_text + ljson.text.slice(last_idx, match.index);
                         expr = match[0].slice(1,-1).split("-");
                         var label_value = ""
-                        if (expr[0]==="time")
+                        if (expr[0]==="time") {
                             label_value = self.model.get_time_label_text(expr[1]);
-						else if (expr[0]==="name"){
+						} else if (expr[0]==="name"){
                             label_value = self.model.get_name_label_text(expr[1]);
 							//Escape the underscore for markdown
 							label_value = label_value.replaceAll("_", "\\_");
 						} else if (expr[0]==="roi"){
                             label_value = self.model.get_roi_label_text(expr[1]);
+						} else if (expr[0]==="depth") {
+                            label_value = self.model.get_depth_label_text(expr[1]);
 						}
 
                         //If label_value hasn't been created (invalid expr[0])

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -21,7 +21,7 @@
             this.listenTo(this.model,
                 'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
                 this.render_image);
-            this.listenTo(this.model, 'change:labels change:theT change:deltaT', this.render_labels);
+            this.listenTo(this.model, 'change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT', this.render_labels);
             this.listenTo(this.model, 'change:shapes', this.render_shapes);
 
             // During drag or resize, model isn't updated, but we trigger 'drag'
@@ -202,6 +202,8 @@
                             label_value = self.model.get_name_label_text(expr[1]);
 							//Escape the underscore for markdown
 							label_value = label_value.replaceAll("_", "\\_");
+						} else if (expr[0]==="roi"){
+                            label_value = self.model.get_roi_label_text(expr[1]);
 						}
 
                         //If label_value hasn't been created (invalid expr[0])

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -198,6 +198,11 @@
                         var label_value = ""
                         if (expr[0]==="time")
                             label_value = self.model.get_time_label_text(expr[1]);
+						else if (expr[0]==="name"){
+                            label_value = self.model.get_name_label_text(expr[1]);
+							//Escape the underscore for markdown
+							label_value = label_value.replaceAll("_", "\\_");
+						}
 
                         //If label_value hasn't been created (invalid expr[0])
                         //  or is empty (invalid expr[1]), the expr is kept unmodified

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -196,21 +196,19 @@
                     var last_idx = 0;
                     for (const match of matches) {// Loops on the match to replace in the ljson.text the expression by their values
                         var new_text = new_text + ljson.text.slice(last_idx, match.index);
-                        expr = match[0].slice(1,-1).split("-");
+                        expr = match[0].slice(1,-1).split(".");
                         var label_value = ""
-                        if (expr[0]==="time") {
-                            label_value = self.model.get_time_label_text(expr[1]);
-						} else if (expr[0]==="name"){
-                            label_value = self.model.get_name_label_text(expr[1]);
-							//Escape the underscore for markdown
-							label_value = label_value.replaceAll("_", "\\_");
-						} else if (expr[0]==="roi"){
-                            label_value = self.model.get_roi_label_text(expr[1]);
-						} else if (expr[0]==="depth") {
-                            label_value = self.model.get_depth_label_text(expr[1]);
-						} else if (expr[0]==="channels") {
+                        if (['time', 't'].includes(expr[0])) {
+                            label_value = self.model.get_time_label_text(expr[1] ? expr[1] : "index");
+                        } else if (['image', 'dataset'].includes(expr[0])){
+                            label_value = self.model.get_name_label_text(expr[0], expr[1] ? expr[1] : "name");
+                            //Escape the underscore for markdown
+                            label_value = label_value.replaceAll("_", "\\_");
+                        } else if (['x', 'y', 'z', 'width', 'height', 'w', 'h', 'rotation', 'rot'].includes(expr[0])){
+                            label_value = self.model.get_view_label_text(expr[0], expr[1] ? expr[1] : "pixel");
+                        } else if (['channels', 'c'].includes(expr[0])) {
                             label_value = self.model.get_channels_label_text();
-						}
+                        }
 
                         //If label_value hasn't been created (invalid expr[0])
                         //  or is empty (invalid expr[1]), the expr is kept unmodified

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -21,7 +21,9 @@
             this.listenTo(this.model,
                 'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
                 this.render_image);
-            this.listenTo(this.model, 'change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ', this.render_labels);
+            this.listenTo(this.model,
+                'change:channels change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ',
+                this.render_labels);
             this.listenTo(this.model, 'change:shapes', this.render_shapes);
 
             // During drag or resize, model isn't updated, but we trigger 'drag'
@@ -206,6 +208,8 @@
                             label_value = self.model.get_roi_label_text(expr[1]);
 						} else if (expr[0]==="depth") {
                             label_value = self.model.get_depth_label_text(expr[1]);
+						} else if (expr[0]==="channels") {
+                            label_value = self.model.get_channels_label_text();
 						}
 
                         //If label_value hasn't been created (invalid expr[0])

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -22,7 +22,7 @@
                 'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
                 this.render_image);
             this.listenTo(this.model,
-                'change:channels change:zoom change:dx change:dy change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ change:z_projection change:z_start change:z_end',
+                'change:channels change:zoom change:dx change:dy change:width change:height change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ change:z_projection change:z_start change:z_end',
                 this.render_labels);
             this.listenTo(this.model, 'change:shapes', this.render_shapes);
 

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -188,12 +188,28 @@
                         ljson.color = '000000';
                     }
                 }
-                if (typeof ljson.text == 'undefined' && ljson.time) {
-                    ljson.text = self.model.get_time_label_text(ljson.time);
-                } else {
-                    // Markdown also escapes all labels so they are safe
-                    ljson.text = markdown.toHTML(ljson.text);
+                const matches = [...ljson.text.matchAll(/\[.+?\]/g)]; // Non greedy regex capturing expressions in []
+                if (matches.length>0){ 
+                    var new_text = "";
+                    var last_idx = 0;
+                    for (const match of matches) {// Loops on the match to replace in the ljson.text the expression by their values
+                        var new_text = new_text + ljson.text.slice(last_idx, match.index);
+                        expr = match[0].slice(1,-1).split("-");
+                        var label_value = ""
+                        if (expr[0]==="time")
+                            label_value = self.model.get_time_label_text(expr[1]);
+
+                        //If label_value hasn't been created (invalid expr[0])
+                        //  or is empty (invalid expr[1]), the expr is kept unmodified
+                        new_text = new_text + (label_value?label_value:match[0]); 
+                        last_idx = match.index + match[0].length;
+                    }
+                    ljson.text = new_text + ljson.text.slice(last_idx);
                 }
+
+                // Markdown also escapes all labels so they are safe
+                ljson.text = markdown.toHTML(ljson.text);
+
                 positions[l.position].push(ljson);
             });
 

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -344,18 +344,6 @@
                 return false;
             }
 
-            if (label_text.slice(0, 5) == '[time') {
-                var format = label_text.slice(6, -1);   // 'secs', 'hrs:mins' etc
-                selected.forEach(function(m) {
-                    m.create_labels_from_time({format: format,
-                            position:position,
-                            size:font_size,
-                            color: color
-                    });
-                });
-                return false;
-            }
-
             if (label_text == '[key-values]') {
                 // Load Map Annotations for this image and create labels
                 $("#labelsFromMapAnns").modal("show", {
@@ -513,12 +501,6 @@
             key = _.escape(key);
             var new_label = {text:label_text, size:font_size, position:position, color:color};
 
-            // if we're editing a 'time' label, preserve the 'time' attribute
-            if (label_text.slice(0, 5) == '[time') {
-                new_label.text = undefined;                 // no 'text'
-                new_label.time = label_text.slice(6, -1);   // 'secs', 'hrs:mins' etc
-            }
-
             var newlbls = {};
             newlbls[key] = new_label;
 
@@ -540,10 +522,6 @@
                     var key = m.get_label_key(l),
                         ljson = $.extend(true, {}, l);
                         ljson.key = key;
-                    if (typeof ljson.text == 'undefined' && ljson.time) {
-                        // show time labels as they are in 'new label' form
-                        ljson.text = '[time-' + ljson.time + "]"
-                    }
                     positions[l.position][key] = ljson;
                 });
             });

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -337,7 +337,7 @@
 
             var selected = this.model.getSelected();
 
-            if (label_text == '[channels]') {
+            if (label_text == '[channels labels]') {
                 selected.forEach(function(m) {
                     m.create_labels_from_channels({position:position, size:font_size});
                 });

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -371,12 +371,6 @@
             };
 
             selected.forEach(function(m) {
-                if (label_text === "[image-name]") {
-                    var pathnames = m.get('name').split('/');
-                    label.text = pathnames[pathnames.length-1];
-                } else if (label_text === "[dataset-name]") {
-                    label.text = m.get('datasetName') ? m.get('datasetName') : "No/Many Datasets";
-                }
                 m.add_labels([label]);
             });
             return false;

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -11,8 +11,8 @@
                 <ul class="dropdown-menu pull-right">
                     <li role="presentation" class="dropdown-header">Create Label(s) From:</li>
                     <li role="presentation" class="divider"></li>
-                    <li><a href="#" data-label="[image-name]">Image Name</a></li>
-                    <li><a href="#" data-label="[dataset-name]">Dataset Name</a></li>
+                    <li><a href="#" data-label="[name-image]">Image Name</a></li>
+                    <li><a href="#" data-label="[name-dataset]">Dataset Name</a></li>
                     <li title="Create labels from active Channels on the selected panel">
                         <a href="#" data-label="[channels]">Channels</a>
                     </li>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -43,6 +43,15 @@
                     <li class="add_time_label">
                         <a href="#" data-label="[time-hrs:mins]">Time (hrs:mins)</a>
                     </li>
+					<li class="add_depth_label"  title="Add a label that shows the current Z-index">
+                        <a href="#" data-label="[depth-index]">Depth (Z-index)</a>
+                    </li>
+                    <li class="add_depth_label"  title="Add a label that shows the current depth">
+                        <a href="#" data-label="[depth-unit]">Depth (unit)</a>
+                    </li>
+					<li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
+                        <a href="#" data-label="X: [roi-x] Y: [roi-y]">X and Y (pixel)</a>
+                    </li>
                 </ul>
             </div>
         <% } %>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -47,19 +47,10 @@
                         <a href="#" data-label="[time.hrs:mins]">Time (hrs:mins)</a>
                     </li>
                     <li title="Add a label that shows the viewport X and Y in pixels">
-                        <a href="#" data-label="X: [x.pixel] Y: [y.pixel]">X and Y (pixel)</a>
-                    </li>
-                    <li title="Add a label that shows the viewport X and Y in units">
-                        <a href="#" data-label="X: [x.unit] Y: [y.unit]">X and Y (unit)</a>
+                        <a href="#" data-label="X: [x.pixel] Y: [y.pixel]">X and Y (pixel or unit)</a>
                     </li>
                     <li  title="Add a label that shows the current Z-index">
-                        <a href="#" data-label="Z: [z.pixel]">Z (pixel)</a>
-                    </li>
-                    <li title="Add a label that shows the current Z in units">
-                        <a href="#" data-label="Z: [z.unit]">Z (unit)</a>
-                    </li>
-                    <li  title="Add a label that shows the current image rotation">
-                        <a href="#" data-label="[rotation]">Rotation (degree)</a>
+                        <a href="#" data-label="Z: [z.pixel]">Z (pixel or unit)</a>
                     </li>
                 </ul>
             </div>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -11,10 +11,15 @@
                 <ul class="dropdown-menu pull-right">
                     <li role="presentation" class="dropdown-header">Create Label(s) From:</li>
                     <li role="presentation" class="divider"></li>
-                    <li><a href="#" data-label="[name-image]">Image Name</a></li>
-                    <li><a href="#" data-label="[name-dataset]">Dataset Name</a></li>
+                    <li><a href="#" data-label="[image.name]">Image Name</a></li>
+                    <li><a href="#" data-label="[image.id]">Image ID</a></li>
+                    <li><a href="#" data-label="[dataset.name]">Dataset Name</a></li>
+                    <li><a href="#" data-label="[dataset.id]">Dataset ID</a></li>
                     <li title="Create labels from active Channels on the selected panel">
-                        <a href="#" data-label="[channels]">Channels</a>
+                        <a href="#" data-label="[channels labels]">Channels (separate label)</a>
+                    </li>
+                    <li title="Create labels from active Channels on the selected panel">
+                        <a href="#" data-label="[channels]">Channels (single label)</a>
                     </li>
                     <li title="Create labels from Tags on this Image in OMERO">
                         <a href="#" data-label="[tags]">Tags</a>
@@ -23,34 +28,37 @@
                         <a href="#" data-label="[key-values]">Key-Value Pairs</a>
                     </li>
                     <li title="Add a label that shows the current T-index">
-                        <a href="#" data-label="[time-index]">Time (T-index)</a>
+                        <a href="#" data-label="[time.index]">Time (T-index)</a>
                     </li>
                     <li class="add_time_label" title="Label shows time in milliseconds">
-                        <a href="#" data-label="[time-milliseconds]">Time (milliseconds)</a>
+                        <a href="#" data-label="[time.milliseconds]">Time (milliseconds)</a>
                     </li>
                     <li class="add_time_label">
-                        <a href="#" data-label="[time-secs]">Time (seconds)</a>
+                        <a href="#" data-label="[time.secs]">Time (seconds)</a>
                     </li>
                     <li class="add_time_label">
-                        <a href="#" data-label="[time-mins]">Time (mins)</a>
+                        <a href="#" data-label="[time.mins]">Time (mins)</a>
                     </li>
                     <li class="add_time_label" title="Label shows time in mins:secs">
-                        <a href="#" data-label="[time-mins:secs]">Time (mins:secs)</a>
+                        <a href="#" data-label="[time.mins:secs]">Time (mins:secs)</a>
                     </li>
                     <li class="add_time_label">
-                        <a href="#" data-label="[time-hrs:mins:secs]">Time (hrs:mins:secs)</a>
+                        <a href="#" data-label="[time.hrs:mins:secs]">Time (hrs:mins:secs)</a>
                     </li>
                     <li class="add_time_label">
-                        <a href="#" data-label="[time-hrs:mins]">Time (hrs:mins)</a>
+                        <a href="#" data-label="[time.hrs:mins]">Time (hrs:mins)</a>
                     </li>
-					<li class="add_depth_label"  title="Add a label that shows the current Z-index">
-                        <a href="#" data-label="[depth-index]">Depth (Z-index)</a>
+                    <li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
+                        <a href="#" data-label="X: [x.pixel] Y: [y.pixel]">X and Y (pixel)</a>
+                    </li>
+                    <li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
+                        <a href="#" data-label="X: [x.unit] Y: [y.unit]">X and Y (unit)</a>
+                    </li>
+                    <li class="add_depth_label"  title="Add a label that shows the current Z-index">
+                        <a href="#" data-label="Z: [z.pixel]">Z (pixel)</a>
                     </li>
                     <li class="add_depth_label"  title="Add a label that shows the current depth">
-                        <a href="#" data-label="[depth-unit]">Depth (unit)</a>
-                    </li>
-					<li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
-                        <a href="#" data-label="X: [roi-x] Y: [roi-y]">X and Y (pixel)</a>
+                        <a href="#" data-label="Z: [z.unit]">Z (unit)</a>
                     </li>
                 </ul>
             </div>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -48,17 +48,20 @@
                     <li class="add_time_label">
                         <a href="#" data-label="[time.hrs:mins]">Time (hrs:mins)</a>
                     </li>
-                    <li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
+                    <li title="Add a label that shows the viewport X and Y in pixels">
                         <a href="#" data-label="X: [x.pixel] Y: [y.pixel]">X and Y (pixel)</a>
                     </li>
-                    <li class="add_roi_label"  title="Add a label that shows the viewport X and Y">
+                    <li title="Add a label that shows the viewport X and Y in units">
                         <a href="#" data-label="X: [x.unit] Y: [y.unit]">X and Y (unit)</a>
                     </li>
-                    <li class="add_depth_label"  title="Add a label that shows the current Z-index">
+                    <li  title="Add a label that shows the current Z-index">
                         <a href="#" data-label="Z: [z.pixel]">Z (pixel)</a>
                     </li>
-                    <li class="add_depth_label"  title="Add a label that shows the current depth">
+                    <li title="Add a label that shows the current Z in units">
                         <a href="#" data-label="Z: [z.unit]">Z (unit)</a>
+                    </li>
+                    <li  title="Add a label that shows the current image rotation">
+                        <a href="#" data-label="[rotation]">Rotation (degree)</a>
                     </li>
                 </ul>
             </div>

--- a/src/templates/labels_form_inner_template.html
+++ b/src/templates/labels_form_inner_template.html
@@ -12,9 +12,7 @@
                     <li role="presentation" class="dropdown-header">Create Label(s) From:</li>
                     <li role="presentation" class="divider"></li>
                     <li><a href="#" data-label="[image.name]">Image Name</a></li>
-                    <li><a href="#" data-label="[image.id]">Image ID</a></li>
                     <li><a href="#" data-label="[dataset.name]">Dataset Name</a></li>
-                    <li><a href="#" data-label="[dataset.id]">Dataset ID</a></li>
                     <li title="Create labels from active Channels on the selected panel">
                         <a href="#" data-label="[channels labels]">Channels (separate label)</a>
                     </li>


### PR DESCRIPTION
PLEASE READ UNTIL THE END BEFORE MERGING (Figure_To_Pdf.py not tested and missing part about JSON version compatibility)

Dear OME team,
this pull request concerns labels, and in particular how special values like time, X/Y/Z or image name are handled.

Before, only "time labels" that were specified like [time-hrs:mins:secs] would be dynamically handled . But that worked only if the text of the label was exactly starting like "[time" and ending with an understood format like "-hrs:mins:secs]".

I changed the behavior so that a regex looks for a value between square brackets [], split the content separated by a "-" character, and replaces the text in the label according to what it found. With all the commits from this PR, the code recognizes:

* [time-...]
  - index
  - milliseconds
  - ... (all that existed before)
 * [name-...]
   - image (that was given before as image-name)
   - dataset (that was given before as dataset-name)
 * [roi-...] (same as the viewport values)
   - x
   - y
   - width
   - height
   - rotation (bonus)
* [depth-...]
  - index
  - unit (display the depth in units, like 17.6 μm)

![grafik](https://user-images.githubusercontent.com/10853316/178304557-fbab994d-2c45-4194-999a-d55adb681da2.png)

 
In my opinion, it simplifies the code, were the "[time" special label was handled in many places and thus was harder to extend. In addition, it permits three new things:
* Text and dynamic labels can be mixed
* Several dynamic labels can be used in a single label
* Markdown can be used on those dynamic labels (and on the text surrounding them)


--------------------------------------------------------------

From there, if you want to merge my updates, we need first to:
- Test Figure_To_Pdf.py (I haven't found a way yet to test it)
- Handle the bumped version of the JSON (src/js/models/figure_model.js). I had to add "data.pixel_size.z" for the depth, but I don't know where to get it from in "version_transform"
- Review the naming of the dynamic labels -> I'm not a great name picker for variables, and I kept what was existing for the parsing (square brackets and values separated by "-"). Maybe you want to change it to something more intuitive now, because it will be annoying to change it in the future

--------------------------------------------------------------

Finally, I found this issue (https://github.com/ome/omero-figure/issues/318) that could be solved by this PR 

Thanks for your thoughts/critics/feedback. I'm also not so experienced in collaborating on Github so I apologize in advance if things are a bit messy here.

Cheers!
Tom