### PR TITLE
Only show legend-container above right panel when editing

### DIFF
--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -139,7 +139,7 @@
 
     /* -- Legend -- */
     .legend-container {
-        z-index: 100;
+        z-index: 1;
         position:fixed;
         bottom: 54px;
         width: 60%;

--- a/src/js/views/legend_view.js
+++ b/src/js/views/legend_view.js
@@ -143,11 +143,14 @@ var LegendView = Backbone.View.extend({
                 var html = '<textarea class="form-control" rows="9" style="resize:none">'
                             + legendText + '</textarea>';
                 $legend.html(html);
+                // Show above the right-hand panel when editing
+                $(".legend-container").css("z-index", 100);
             } else {
                 // ...only show 'edit' button
                 $edit.show();
                 $save.hide();
                 $cancel.hide();
+                $(".legend-container").css("z-index", 1);
 
                 $panel.removeClass('editing');
                 if (legendText.length === 0) {


### PR DESCRIPTION
This fixes a minor issue where the right-panel (or part of it like a drop-down list) falls behind the legend button (see screenshot). Only happens when the screen is small and/or the drop-down list is longer (see #472):

![Screenshot 2022-08-08 at 14 10 46](https://user-images.githubusercontent.com/900055/183426193-f06960db-3314-42a6-b089-93accdfc2bd9.png)


With the fix, the legend controls and the legend itself only shows above the right panel when you are editing the legend.