### PR TITLE
Changelog 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -------------------
 
 - Support more dynamic label options (Thanks to Tom Boissonnet) ([#472](https://github.com/ome/omero-figure/pull/472))
+  - This includes an update to the [Figure file format](https://github.com/ome/omero-figure/blob/master/docs/figure_file_format.rst)
 - Add custom gap size between image panels ([#470](https://github.com/ome/omero-figure/pull/470))
 - Channel sliders handle floating-point images ([#468](https://github.com/ome/omero-figure/pull/468))
 - Fix legend button overlaying right-panel menus ([#474](https://github.com/ome/omero-figure/pull/474))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-4.5.0 (August 2022)
+5.0.0 (August 2022)
 -------------------
 
 - Support more dynamic label options (Thanks to Tom Boissonnet) ([#472](https://github.com/ome/omero-figure/pull/472))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+4.5.0 (August 2022)
+-------------------
+
+- Support more dynamic label options (Thanks to Tom Boissonnet) ([#472](https://github.com/ome/omero-figure/pull/472))
+- Add custom gap size between image panels ([#470](https://github.com/ome/omero-figure/pull/470))
+- Channel sliders handle floating-point images ([#468](https://github.com/ome/omero-figure/pull/468))
+- Fix legend button overlaying right-panel menus ([#474](https://github.com/ome/omero-figure/pull/474))
+
 4.4.3 (March 2022)
 ------------------
 


### PR DESCRIPTION
Was previously #475 (v4.5.0) but changes to the JSON file format could be considered a breaking change (if any users are manually passing v5 format JSON to the updated Figure_To_Pdf.py script).

