### PR TITLE
Multi label text fix

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1267,7 +1267,7 @@ class FigureExport(object):
                     label_value = " ".join(label_value)
 
                 new_text.append(label_value if label_value else item.group())
-                last_idx += item.end()
+                last_idx = item.end()
 
             new_text.append(l['text'][last_idx:])
             l['text'] = "".join(new_text)


### PR DESCRIPTION
Hi Will,
a quick fix for a bug I spotted in the pdf export. 
The "regular" text added after the 2nd dynamic label is cropped or ignored (`last_idx` was incremented instead of keeping track of the regex end position)

Should I make a post on image.sc to mention the bug and the steps to fix it? 
Replacing the latest script with this one should suffice.