### PR TITLE
Default figure filename to YYYY-MM-DD_hh-mm-ss

### DIFF
--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -550,9 +550,14 @@
         },
 
         getDefaultFigureName: function() {
+            const padL = (nr, len = 2, chr = `0`) => `${nr}`.padStart(2, chr);
             var d = new Date(),
-                dt = d.getFullYear() + "-" + (d.getMonth()+1) + "-" +d.getDate(),
-                tm = d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds();
+                dt = [d.getFullYear(),
+                      padL(d.getMonth()+1),
+                      padL(d.getDate())].join('-'),
+                tm = [padL(d.getHours()),
+                      padL(d.getMinutes()),
+                      padL(d.getSeconds())].join('-');
             return "Figure_" + dt + "_" + tm;
         },
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -550,7 +550,7 @@
         },
 
         getDefaultFigureName: function() {
-            const padL = (nr, len = 2, chr = `0`) => `${nr}`.padStart(2, chr);
+            const padL = (nr) => `${nr}`.padStart(2, '0');
             var d = new Date(),
                 dt = [d.getFullYear(),
                       padL(d.getMonth()+1),


### PR DESCRIPTION
Hello Will,
tiny PR to replace `:` by `-` for the default figure filename, to solve https://github.com/ome/omero-figure/issues/314

That also includes the padding of date and time with zeros

If you would rather keep the `:`, I can revert to that format but keep the padding (otherwise reject the PR :D).


Side note, could you also close those solved issues:
- https://github.com/ome/omero-figure/issues/318  -> solved by https://github.com/ome/omero-figure/pull/472
- https://github.com/ome/omero-figure/issues/441 -> solved by https://github.com/ome/omero-figure/pull/481
- https://github.com/ome/omero-figure/issues/442 -> solved by https://github.com/ome/omero-figure/pull/481

Best,
Tom