### PR TITLE
Add option to adjust Scalebar width

### DIFF
--- a/docs/figure_file_format.rst
+++ b/docs/figure_file_format.rst
@@ -36,7 +36,7 @@ This is an example of a minimal OMERO.figure JSON file::
 
     {
     // see older versions below
-    "version": 6,
+    "version": 7,
     "panels": [
         {
             // position of the panel on the page
@@ -234,6 +234,10 @@ that lines will not appear thicker on a panel when it is zoomed in. Supported Sh
 
 Version history
 ----------------
+
+New in version 7:
+
+- `scalebar`: added 'height': <integer>
 
 New in version 6:
 

--- a/docs/figure_file_format.rst
+++ b/docs/figure_file_format.rst
@@ -91,6 +91,7 @@ Optional settings for each panel::
     "scalebar": {
         "show": true,
         "length": 10,
+        "height": 3,
         "units": "MICROMETER",
         "position": "bottomright",  // topright, topleft, bottomleft
         "color": "FFFFFF",

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2217,10 +2217,8 @@ class TiffExport(FigureExport):
         y2 = scale_to_export_dpi(y2)
         width = scale_to_export_dpi(width)
 
-        for l in range(width):
-            draw.line([(x, y), (x2, y2)], fill=rgb)
-            y += 1
-            y2 += 1
+        for l in range(-width // 2, width // 2):
+            draw.line([(x, y+l), (x2, y2+l)], fill=rgb)
 
     def draw_temp_label(self, text, fontsize, rgb):
         """Returns a new PIL image with text. Handles html."""

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1493,8 +1493,9 @@ class FigureExport(object):
                 pass
 
             # For 'bottom' scalebar, put label above
+            # 5 is an empirically determined offset that "works"
             if 'bottom' in position:
-                ly = ly - font_size
+                ly = ly - font_size - 5
             else:
                 ly = ly + 5
 
@@ -2297,7 +2298,6 @@ class TiffExport(FigureExport):
     def draw_text(self, text, x, y, fontsize, rgb, align="center"):
         """ Add text to the current figure page """
         x = scale_to_export_dpi(x)
-        y = y - 5       # seems to help, but would be nice to fix this!
         y = scale_to_export_dpi(y)
         fontsize = scale_to_export_dpi(fontsize)
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -901,7 +901,7 @@ class FigureExport(object):
         if self.zip_folder_name is not None:
             full_name = os.path.join(self.zip_folder_name, full_name)
 
-        while(os.path.exists(full_name)):
+        while os.path.exists(full_name):
             index += 1
             full_name = "%s_page_%02d.%s" % (name, index, fext)
             if self.zip_folder_name is not None:
@@ -1477,7 +1477,8 @@ class FigureExport(object):
         else:
             lx_end = lx - canvas_length
 
-        self.draw_scalebar_line(lx, ly, lx_end, ly, sb["height"], (red, green, blue))
+        self.draw_scalebar_line(lx, ly, lx_end, ly, sb["height"],
+                                (red, green, blue))
 
         if 'show_label' in sb and sb['show_label']:
             symbol = u"\u00B5m"

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1434,19 +1434,20 @@ class FigureExport(object):
         position = 'position' in sb and sb['position'] or 'bottomright'
         align = 'left'
 
+        half_height = sb['height'] // 2
         if position == 'topleft':
             lx = x + spacer
-            ly = y + spacer
+            ly = y + spacer + half_height
         elif position == 'topright':
             lx = x + width - spacer
-            ly = y + spacer
+            ly = y + spacer + half_height
             align = "right"
         elif position == 'bottomleft':
             lx = x + spacer
-            ly = y + height - spacer
+            ly = y + height - spacer - half_height
         elif position == 'bottomright':
             lx = x + width - spacer
-            ly = y + height - spacer
+            ly = y + height - spacer - half_height
             align = "right"
 
         pixel_size_x = panel['pixel_size_x']
@@ -1476,7 +1477,7 @@ class FigureExport(object):
         else:
             lx_end = lx - canvas_length
 
-        self.draw_scalebar_line(lx, ly, lx_end, ly, 3, (red, green, blue))
+        self.draw_scalebar_line(lx, ly, lx_end, ly, sb["height"], (red, green, blue))
 
         if 'show_label' in sb and sb['show_label']:
             symbol = u"\u00B5m"
@@ -1498,7 +1499,10 @@ class FigureExport(object):
                 ly = ly + 5
 
             self.draw_text(
-                label, (lx + lx_end)/2, ly, font_size, (red, green, blue),
+                label, (lx + lx_end)/2,
+                ly + ((-1 if position in ["bottomleft", "bottomright"]
+                       else 1) * half_height),
+                font_size, (red, green, blue),
                 align="center")
 
     def is_big_image(self, image):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1477,7 +1477,7 @@ class FigureExport(object):
         else:
             lx_end = lx - canvas_length
 
-        self.draw_scalebar_line(lx, ly, lx_end, ly, sb["height"],
+        self.draw_scalebar_line(lx, ly, lx_end, ly, sb.get("height", 3),
                                 (red, green, blue))
 
         if 'show_label' in sb and sb['show_label']:

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1434,7 +1434,7 @@ class FigureExport(object):
         position = 'position' in sb and sb['position'] or 'bottomright'
         align = 'left'
 
-        half_height = sb['height'] // 2
+        half_height = sb.get('height', 3) // 2
         if position == 'topleft':
             lx = x + spacer
             ly = y + spacer + half_height

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -287,6 +287,7 @@
         align-items: center;
         display: flex;
     }
+
     .scalebar_form .scalebar_length {
         padding-right: 0;
     }
@@ -297,7 +298,7 @@
 
     .scalebar_form .scalebar_unit {
         padding-left: 0;
-        padding-right: 10px
+        padding-right: 10px;
     }
 
     .scalebar {

--- a/omero_figure/static/figure/css/figure.css
+++ b/omero_figure/static/figure/css/figure.css
@@ -275,12 +275,32 @@
     }
 
     .scalebar_form .input-group {
-        width:50px;
+        width:80px;
         margin-right: 4px;
     }
 
+    .scalebar_form .form-group {
+        margin-bottom: 0;
+    }
+
+    .scalebar_form .row {
+        align-items: center;
+        display: flex;
+    }
+    .scalebar_form .scalebar_length {
+        padding-right: 0;
+    }
+
+    .scalebar_form .scalebar_text {
+        padding-right: 0;
+    }
+
+    .scalebar_form .scalebar_unit {
+        padding-left: 0;
+        padding-right: 10px
+    }
+
     .scalebar {
-        height: 3px;
         position: absolute;
         margin: 5% !important;
     }

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -1,7 +1,7 @@
     
     // Version of the json file we're saving.
     // This only needs to increment when we make breaking changes (not linked to release versions.)
-    var VERSION = 6;
+    var VERSION = 7;
 
 
     // ------------------------- Figure Model -----------------------------------
@@ -260,6 +260,16 @@
                 });
             }
 
+            if (v < 7) {
+                console.log("Transforming to VERSION 7");
+                // Adding the height parameter to the JSON
+                _.each(json.panels, function(p){
+                    // rename lineWidth to strokeWidth
+                    if (p.scalebar && !p.scalebar.height) {
+                        p.scalebar.height = 3;
+                    }
+                });
+            }
             return json;
         },
 

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -280,7 +280,6 @@
                 sb_json.font_size = sb.font_size;
                 sb_json.show_label = sb.show_label;
                 sb_json.symbol = sb.units;
-                console.log(sb.height)
                 // Use global LENGTH_UNITS to get symbol for unit.
                 if (window.LENGTH_UNITS && window.LENGTH_UNITS[sb.units]){
                     sb_json.symbol = window.LENGTH_UNITS[sb.units].symbol;

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -276,10 +276,11 @@
                 sb_json.position = sb.position;
                 sb_json.color = sb.color;
                 sb_json.length = sb.length;
+                sb_json.height = sb.height;
                 sb_json.font_size = sb.font_size;
                 sb_json.show_label = sb.show_label;
                 sb_json.symbol = sb.units;
-
+                console.log(sb.height)
                 // Use global LENGTH_UNITS to get symbol for unit.
                 if (window.LENGTH_UNITS && window.LENGTH_UNITS[sb.units]){
                     sb_json.symbol = window.LENGTH_UNITS[sb.units].symbol;

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -27,7 +27,7 @@ var ScalebarFormView = Backbone.View.extend({
         "click .pixel_size_display": "edit_pixel_size",
         "keypress .pixel_size_input"  : "enter_pixel_size",
         "blur .pixel_size_input"  : "save_pixel_size",
-        //"keyup input[type='text']"  : "handle_keyup",
+        "keyup input[type='text']"  : "handle_keyup",
      },
 
     handle_keyup: function (event) {
@@ -82,7 +82,7 @@ var ScalebarFormView = Backbone.View.extend({
     // called when form changes
     update_scalebar: function(event) {
 
-        var $form = $('#scalebar_form');
+        var $form = $('.scalebar_form ');
 
         var length = $('.scalebar-length', $form).val(),
             units = $('.scalebar-units span:first', $form).attr('data-unit'),

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -207,6 +207,7 @@ var ScalebarFormView = Backbone.View.extend({
 
         var html = this.template(json);
         this.$el.html(html);
+        this.$el.find("[title]").tooltip();
 
         return this;
     }

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -81,7 +81,8 @@ var ScalebarFormView = Backbone.View.extend({
             position = $('.label-position span:first', $form).attr('data-position'),
             color = $('.label-color span:first', $form).attr('data-color'),
             show_label = $('.scalebar_label', $form).prop('checked'),
-            font_size = $('.scalebar_font_size span:first', $form).text().trim();
+            font_size = $('.scalebar_font_size span:first', $form).text().trim(),
+            height = $('.scalebar-height', $form).val();
 
         this.models.forEach(function(m){
             var old_sb = m.get('scalebar');
@@ -104,6 +105,7 @@ var ScalebarFormView = Backbone.View.extend({
             if (color != '-') sb.color = color;
             sb.show_label = show_label;
             if (font_size != '-') sb.font_size = font_size;
+            if (height != '-') sb.height = height;
 
             m.save_scalebar(sb);
         });
@@ -161,6 +163,7 @@ var ScalebarFormView = Backbone.View.extend({
                     json.color = sb.color;
                     json.show_label = sb.show_label;
                     json.font_size = sb.font_size;
+                    json.height = sb.height;
                 }
                 else {
                     // combine attributes. Use '-' if different values found
@@ -170,6 +173,7 @@ var ScalebarFormView = Backbone.View.extend({
                     if (json.color != sb.color) json.color = '-';
                     if (!sb.show_label) json.show_label = false;
                     if (json.font_size != sb.font_size) json.font_size = '-';
+                    if (json.height != sb.height) json.height = '-';
                 }
             }
             // if any panels don't have scalebar - we allow to add
@@ -191,6 +195,7 @@ var ScalebarFormView = Backbone.View.extend({
         json.color = json.color || 'FFFFFF';
         json.font_size = json.font_size || 10;
         json.pixel_size_symbol = json.pixel_size_symbol || '-';
+        json.height = json.height || 3;
 
         var html = this.template(json);
         this.$el.html(html);

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -82,7 +82,7 @@ var ScalebarFormView = Backbone.View.extend({
             color = $('.label-color span:first', $form).attr('data-color'),
             show_label = $('.scalebar_label', $form).prop('checked'),
             font_size = $('.scalebar_font_size span:first', $form).text().trim(),
-            height = $('.scalebar-height', $form).val();
+            height = parseInt($('.scalebar-height', $form).val());
 
         this.models.forEach(function(m){
             var old_sb = m.get('scalebar');

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -27,7 +27,15 @@ var ScalebarFormView = Backbone.View.extend({
         "click .pixel_size_display": "edit_pixel_size",
         "keypress .pixel_size_input"  : "enter_pixel_size",
         "blur .pixel_size_input"  : "save_pixel_size",
-    },
+        //"keyup input[type='text']"  : "handle_keyup",
+     },
+
+    handle_keyup: function (event) {
+        // If Enter key - submit form...
+        if (event.which == 13) {
+            this.update_scalebar();
+        }
+    }, 
 
     // simply show / hide editing field
     edit_pixel_size: function() {
@@ -74,7 +82,7 @@ var ScalebarFormView = Backbone.View.extend({
     // called when form changes
     update_scalebar: function(event) {
 
-        var $form = $('#scalebar_form form');
+        var $form = $('#scalebar_form');
 
         var length = $('.scalebar-length', $form).val(),
             units = $('.scalebar-units span:first', $form).attr('data-unit'),

--- a/src/templates/scalebar_form_template.html
+++ b/src/templates/scalebar_form_template.html
@@ -122,7 +122,7 @@
                 <input type="checkbox" class="scalebar_label" <% if (show_label) print("checked") %> /> 
             </div>
             <div class="form-group col-sm-1 btn-group" style="padding: 0;">
-                <button type="button" class="scalebar_font_size btn btn-default btn-sm dropdown-toggle" title="Label Size"
+                <button type="button" class="scalebar_font_size btn btn-default btn-sm dropdown-toggle" title="Font Size"
                 data-toggle="dropdown" style="width:33px; <% if (!show_label) print("display:none") %>">
                     <span><%= font_size %></span>
                     <span class="caret"></span>

--- a/src/templates/scalebar_form_template.html
+++ b/src/templates/scalebar_form_template.html
@@ -20,11 +20,11 @@
                 Length
             </div>
             <div class="form-group col-sm-2 scalebar_length">
-                <input type="text" id="inputScaleBarLength" class="scalebar-length form-control col-sm-4" 
+                <input type="text" class="scalebar-length form-control col-sm-4 input-sm" 
                             placeholder="Length" value="<%= length %>" />
             </div>
-            <div class="form-group col-sm-auto btn-group scalebar_unit">
-                <button type="button" class="scalebar-units btn btn-default dropdown-toggle"
+            <div class="form-group col-sm-1 btn-group scalebar_unit">
+                <button type="button" class="scalebar-units btn btn-default btn-sm dropdown-toggle"
                         title="Units" data-toggle="dropdown">
                     <span data-unit="<%= units %>"><%= units_symbol %></span>
                     <span class="caret"></span>
@@ -35,9 +35,44 @@
                     <% }); %>
                 </ul>
             </div>
-            <div class="form-group col-sm-1" />
+            <div class="col-sm-1" />
+            <div class="form-group col-sm-2 scalebar_text">
+                Height
+            </div>
+            <div class="form-group col-sm-2 scalebar_length">
+                <input type="text" class="scalebar-height form-control input-sm" 
+                placeholder="Height" value="<%= height %>" />
+            </div>
+            <div class="form-group col-sm-1 scalebar_text" style="padding-left: 2px;">
+                px
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="form-group col-sm-2 scalebar_text">
+                Label
+            </div>
+            <div class="form-group col-sm-1">
+                <input type="checkbox" class="scalebar_label" <% if (show_label) print("checked") %> /> 
+            </div>
             <div class="form-group col-sm-auto btn-group">
-                <button type="button" class="label-position btn btn-default dropdown-toggle" 
+                <button type="button" class="scalebar_font_size btn btn-default btn-sm dropdown-toggle" title="Label Size"
+                data-toggle="dropdown" style="width:33px; <% if (!show_label) print("display:none") %>">
+                    <span><%= font_size %></span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                <% _.each([6,8,10,12,14,18,21,24,36,48],function(p){
+                    print ("<li><a href='#'><span>"+p+"</span></a></li>")
+                }); %>
+                </ul>
+            </div>
+            <div class="form-group col-sm-1 scalebar_text" style="padding-left: 2px;">
+                <% if (show_label) print("pt") %>
+            </div>
+            <div class="col-sm-1" />
+            <div class="form-group col-sm-auto btn-group">
+                <button type="button" class="label-position btn btn-default btn-sm dropdown-toggle" 
                         title="Position" data-toggle="dropdown">
                     <span data-position="<%= position %>" class="labelicon-<%= position %> glyphicon 
                         <% if (_.contains(['top','bottom','left','right'],position)) print('glyphicon-log-out'); else {print('glyphicon-new-window')} %>"></span>
@@ -64,7 +99,7 @@
                 </ul>
             </div>
             <div class="form-group col-sm-auto btn-group">
-                <button type="button" class="label-color btn btn-default dropdown-toggle" title="Label Color"
+                <button type="button" class="label-color btn btn-default btn-sm dropdown-toggle" title="Label Color"
                     data-toggle="dropdown">
                     <span data-color="<%= color %>" style="background-color:#<%= color %>">&nbsp &nbsp &nbsp</span>
                     <span class="caret"></span>
@@ -93,43 +128,12 @@
                     </a></li>
                 </ul>
             </div>
-        </div>
-        <div class="row">
-            <div class="form-group col-sm-2 scalebar_text">
-                Height
-            </div>
-            <div class="form-group col-sm-2 scalebar_length">
-                <input type="text" class="scalebar-height form-control" 
-                placeholder="Height" value="<%= height %>" />
-            </div>
-            <div class="form-group col-sm-1 scalebar_text" style="padding-left: 2px;">
-                px
-            </div>
-        </div>
-        <div class="row">
-            <div class="form-group col-sm-2 scalebar_text">
-                Label?
-            </div>
-            <div class="form-group col-sm-2" style="display:flex; justify-content: center; align-items: center;">
-                <input type="checkbox" class="scalebar_label" <% if (show_label) print("checked") %> /> 
-            </div>
-            <div class="form-group col-sm-auto btn-group">
-                <button type="button" class="scalebar_font_size btn btn-default dropdown-toggle" title="Label Size"
-                data-toggle="dropdown" style="width:33px; <% if (!show_label) print("display:none") %>">
-                    <span><%= font_size %></span>
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" role="menu">
-                <% _.each([6,8,10,12,14,18,21,24,36,48],function(p){
-                    print ("<li><a href='#'><span>"+p+"</span></a></li>")
-                }); %>
-                </ul>
-            </div>
-            <div class="form-group col-sm-6" style="display:flex; justify-content: right;">
+            <div class="col-sm-1" />
+            <div class="col-sm-6">
                 <% if (show){ %>
-                    <button type="submit" class="show_scalebar btn btn-success pull-right">Show</button>
+                    <button type="submit" class="show_scalebar btn btn-sm btn-success pull-right">Show</button>
                 <% } else { %>
-                    <button type="button" class="hide_scalebar btn btn-default pull-right">Hide</button>
+                    <button type="button" class="hide_scalebar btn btn-default btn-sm pull-right">Hide</button>
                 <% } %>
             </div>
         </div>

--- a/src/templates/scalebar_form_template.html
+++ b/src/templates/scalebar_form_template.html
@@ -13,111 +13,124 @@
                     {print(pixel_size_x + " " + pixel_size_symbol)} %>
             </span>
         </div>
-
     </div>
-
-    <form class="scalebar_form form-inline">
-
-    <div class="input-group pull-left">
-        <input type="text" class="scalebar-length form-control input-sm" 
-                placeholder="Length" value="<%= length %>" />
-    </div>
-
-    <!-- units -->
-    <div class="btn-group">
-        <button type="button" class="scalebar-units btn btn-default btn-sm dropdown-toggle"
-                title="Units" data-toggle="dropdown">
-            <span data-unit="<%= units %>"><%= units_symbol %></span>
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu" role="menu">
-            <% _.each(unit_symbols, function(u){ %>
-                <li><a href='#'><%= u.unit %> (<span data-unit="<%= u.unit %>"><%= u.symbol %></span>)</a></li>
-            <% }); %>
-        </ul>
-    </div>
-
-    <div class="btn-group">
-        <button type="button" class="label-position btn btn-default btn-sm dropdown-toggle" 
-                title="Position" data-toggle="dropdown">
-            <span data-position="<%= position %>" class="labelicon-<%= position %> glyphicon 
-                <% if (_.contains(['top','bottom','left','right'],position)) print('glyphicon-log-out'); else {print('glyphicon-new-window')} %>"></span>
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu" role="menu">
-            <li role="presentation" class="dropdown-header">Inside Corners</li>
-            <li><a href="#">
-                <span data-position="topleft" class="labelicon-topleft glyphicon glyphicon-new-window"></span>
-                Top Left</a>
-            </li>
-            <li><a href="#">
-                <span data-position="topright" class="labelicon-topright glyphicon glyphicon-new-window"></span>
-                Top Right</a>
-            </li>
-            <li><a href="#">
-                <span data-position="bottomleft" class="labelicon-bottomleft glyphicon glyphicon-new-window"></span>
-                Bottom Left</a>
-            </li>
-            <li><a href="#">
-                <span data-position="bottomright" class="labelicon-bottomright glyphicon glyphicon-new-window"></span>
-                Bottom Right</a>
-            </li>
-        </ul>
-    </div>
-
-    <div class="btn-group">
-        <button type="button" class="label-color btn btn-default btn-sm dropdown-toggle" title="Label Color"
-            data-toggle="dropdown">
-            <span data-color="<%= color %>" style="background-color:#<%= color %>">&nbsp &nbsp &nbsp</span>
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu colorpicker" role="menu">
-            <li><a href="#">
-                <span data-color="000000" style="background-color:#000">&nbsp &nbsp &nbsp</span>&nbsp Black
-            </a></li>
-            <li><a href="#">
-                <span data-color="0000FF" style="background-color:#00f">&nbsp &nbsp &nbsp</span>&nbsp Blue
-            </a></li>
-            <li><a href="#">
-                <span data-color="00FF00" style="background-color:#0f0">&nbsp &nbsp &nbsp</span>&nbsp Green
-            </a></li>
-            <li><a href="#">
-                <span data-color="FF0000" style="background-color:#f00">&nbsp &nbsp &nbsp</span>&nbsp Red
-            </a></li>
-            <li><a href="#">
-                <span data-color="FFFF00" style="background-color:#ff0">&nbsp &nbsp &nbsp</span>&nbsp Yellow
-            </a></li>
-            <li><a href="#">
-                <span data-color="FFFFFF" style="background-color:#fff">&nbsp &nbsp &nbsp</span>&nbsp White
-            </a></li>
-            <li><a href="#">
-                <span data-color="FF00FF" style="background-color:#f0f">&nbsp &nbsp &nbsp</span>&nbsp Magenta
-            </a></li>
-        </ul>
-    </div>
-
-    <div class="checkbox">
-        <label>
-            <input type="checkbox" class="scalebar_label" <% if (show_label) print("checked") %> > Label
-        </label>
-    </div>
-
-    <div class="btn-group">
-        <button type="button" class="scalebar_font_size btn btn-default btn-sm dropdown-toggle" title="Label Size"
-            data-toggle="dropdown" style="width:33px; <% if (!show_label) print("display:none") %>">
-            <span><%= font_size %></span>
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu" role="menu">
-        <% _.each([6,8,10,12,14,18,21,24,36,48],function(p){
-            print ("<li><a href='#'><span>"+p+"</span></a></li>")
-        }); %>
-        </ul>
-    </div>
-
-    <% if (show){ %>
-        <button type="submit" class="show_scalebar btn btn-sm btn-success pull-right">Show</button>
-    <% } else { %>
-        <button type="button" class="hide_scalebar btn btn-sm btn-default pull-right">Hide</button>
-    <% } %>
+    <form class="scalebar_form">
+        <div class="row">
+            <div class="form-group col-sm-2 scalebar_text">
+                Length
+            </div>
+            <div class="form-group col-sm-2 scalebar_length">
+                <input type="text" id="inputScaleBarLength" class="scalebar-length form-control col-sm-4" 
+                            placeholder="Length" value="<%= length %>" />
+            </div>
+            <div class="form-group col-sm-auto btn-group scalebar_unit">
+                <button type="button" class="scalebar-units btn btn-default dropdown-toggle"
+                        title="Units" data-toggle="dropdown">
+                    <span data-unit="<%= units %>"><%= units_symbol %></span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                    <% _.each(unit_symbols, function(u){ %>
+                        <li><a href='#'><%= u.unit %> (<span data-unit="<%= u.unit %>"><%= u.symbol %></span>)</a></li>
+                    <% }); %>
+                </ul>
+            </div>
+            <div class="form-group col-sm-1" />
+            <div class="form-group col-sm-auto btn-group">
+                <button type="button" class="label-position btn btn-default dropdown-toggle" 
+                        title="Position" data-toggle="dropdown">
+                    <span data-position="<%= position %>" class="labelicon-<%= position %> glyphicon 
+                        <% if (_.contains(['top','bottom','left','right'],position)) print('glyphicon-log-out'); else {print('glyphicon-new-window')} %>"></span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                    <li role="presentation" class="dropdown-header">Inside Corners</li>
+                    <li><a href="#">
+                        <span data-position="topleft" class="labelicon-topleft glyphicon glyphicon-new-window"></span>
+                        Top Left</a>
+                    </li>
+                    <li><a href="#">
+                        <span data-position="topright" class="labelicon-topright glyphicon glyphicon-new-window"></span>
+                        Top Right</a>
+                    </li>
+                    <li><a href="#">
+                        <span data-position="bottomleft" class="labelicon-bottomleft glyphicon glyphicon-new-window"></span>
+                        Bottom Left</a>
+                    </li>
+                    <li><a href="#">
+                        <span data-position="bottomright" class="labelicon-bottomright glyphicon glyphicon-new-window"></span>
+                        Bottom Right</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="form-group col-sm-auto btn-group">
+                <button type="button" class="label-color btn btn-default dropdown-toggle" title="Label Color"
+                    data-toggle="dropdown">
+                    <span data-color="<%= color %>" style="background-color:#<%= color %>">&nbsp &nbsp &nbsp</span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu colorpicker" role="menu">
+                    <li><a href="#">
+                        <span data-color="000000" style="background-color:#000">&nbsp &nbsp &nbsp</span>&nbsp Black
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="0000FF" style="background-color:#00f">&nbsp &nbsp &nbsp</span>&nbsp Blue
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="00FF00" style="background-color:#0f0">&nbsp &nbsp &nbsp</span>&nbsp Green
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="FF0000" style="background-color:#f00">&nbsp &nbsp &nbsp</span>&nbsp Red
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="FFFF00" style="background-color:#ff0">&nbsp &nbsp &nbsp</span>&nbsp Yellow
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="FFFFFF" style="background-color:#fff">&nbsp &nbsp &nbsp</span>&nbsp White
+                    </a></li>
+                    <li><a href="#">
+                        <span data-color="FF00FF" style="background-color:#f0f">&nbsp &nbsp &nbsp</span>&nbsp Magenta
+                    </a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="row">
+            <div class="form-group col-sm-2 scalebar_text">
+                Height
+            </div>
+            <div class="form-group col-sm-2 scalebar_length">
+                <input type="text" class="scalebar-height form-control" 
+                placeholder="Height" value="<%= height %>" />
+            </div>
+            <div class="form-group col-sm-1 scalebar_text" style="padding-left: 2px;">
+                px
+            </div>
+        </div>
+        <div class="row">
+            <div class="form-group col-sm-2 scalebar_text">
+                Label?
+            </div>
+            <div class="form-group col-sm-2" style="display:flex; justify-content: center; align-items: center;">
+                <input type="checkbox" class="scalebar_label" <% if (show_label) print("checked") %> /> 
+            </div>
+            <div class="form-group col-sm-auto btn-group">
+                <button type="button" class="scalebar_font_size btn btn-default dropdown-toggle" title="Label Size"
+                data-toggle="dropdown" style="width:33px; <% if (!show_label) print("display:none") %>">
+                    <span><%= font_size %></span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                <% _.each([6,8,10,12,14,18,21,24,36,48],function(p){
+                    print ("<li><a href='#'><span>"+p+"</span></a></li>")
+                }); %>
+                </ul>
+            </div>
+            <div class="form-group col-sm-6" style="display:flex; justify-content: right;">
+                <% if (show){ %>
+                    <button type="submit" class="show_scalebar btn btn-success pull-right">Show</button>
+                <% } else { %>
+                    <button type="button" class="hide_scalebar btn btn-default pull-right">Hide</button>
+                <% } %>
+            </div>
+        </div>
     </form>

--- a/src/templates/scalebar_panel_template.html
+++ b/src/templates/scalebar_panel_template.html
@@ -1,7 +1,9 @@
 
     <div class="scalebar label_<%= position %>" style="background-color: #<%= color %>; height: <%= height %>px">
         <% if (show_label) { %>
-            <div class='scalebar-label' style='color: #<%= color %>; font-size: <%= font_size %>px; margin-bottom: <%= height %>px'>
+            <div class='scalebar-label' style='color: #<%= color %>; font-size: <%= font_size %>px;
+            <% if(position === "bottomleft"  || position === "bottomright") print("margin-bottom:" + height);%>px;
+            <% if(position === "topleft"  || position === "topright") print("margin-top:" + height);%>px;'>
                 <%= length %> <%= symbol %>
             </div>
         <% } %>

--- a/src/templates/scalebar_panel_template.html
+++ b/src/templates/scalebar_panel_template.html
@@ -1,7 +1,7 @@
 
-    <div class="scalebar label_<%= position %>" style="background-color: #<%= color %>">
+    <div class="scalebar label_<%= position %>" style="background-color: #<%= color %>; height: <%= height %>px">
         <% if (show_label) { %>
-            <div class='scalebar-label' style='color: #<%= color %>; font-size: <%= font_size %>px'>
+            <div class='scalebar-label' style='color: #<%= color %>; font-size: <%= font_size %>px; margin-bottom: <%= height %>px'>
                 <%= length %> <%= symbol %>
             </div>
         <% } %>


### PR DESCRIPTION
Hey all,


This is a first draft to Fix #503 

I have added an additional input field to the scalebar_form panel and reordered the inputs to make space.
Adjusting the scalebar in the panel_view is done.

![image](https://user-images.githubusercontent.com/53080416/227196138-422d7016-88aa-41a5-8ec3-b26aac0fa8a1.png)

![image](https://user-images.githubusercontent.com/53080416/227196176-ed37b971-3eda-417b-9c7d-ff0f7cee211e.png)


Known Issue: Site load show Empty string passed to getElementbyId(). This will also be returned multiple times when the scalebar is shown / hidden. Unclear where this is coming from


RFC: Is that approach in principle okay? If yes, I will try to track done that getElementbyId() thing and take a look on what needs to be modified in the export routines.

// Julian
