### PR TITLE
Add top-level Git mailmap to normalize commit author variants

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk> 
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <aleksandra-tarkowska@users.noreply.github.com>
+Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
+David Pinto <david.pinto@bioch.ox.ac.uk> <carandraug+dev@gmail.com>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Jean-Marie Burel <j.burel@dundee.ac.uk>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Julian Hniopek <julian.hniopek@uni-jena.de> <53080416+JulianHn@users.noreply.github.com>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Tom Boissonnet <tom.boissonnet@hhu.de>
+Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>


### PR DESCRIPTION
This mapping file aims to associate all commits from the same contributor to a single "First Name Last Name <email>" author line. The University of Dundee or the Glencoe Software email address are used as the canonical address for current employees of these institutions. For contributors with an executed CLA, the email address specified in the  CLA is used as the canonical one.
