### PR TITLE
Annotation inheritance support

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -990,18 +990,18 @@
             var image_ids = this.map(function(s){return s.get('imageId')})
             image_ids = "image=" + image_ids.join("&image=");
             // TODO: Use /api/ when annotations is supported
-            var url = WEBINDEX_URL + "api/annotations/?type=tag&parents=yes&limit=1000&" + image_ids;
+            var url = WEBINDEX_URL + "api/annotations/?type=tag&parents=true&limit=1000&" + image_ids;
             $.getJSON(url, function(data){
                 // Map {iid: {id: 'tag'}, {id: 'names'}}
-                if (data.hasOwnProperty('inherited')){
-                    data.inherited.annotations.forEach(function(ann) {
+                if (data.hasOwnProperty('parents')){
+                    data.parents.annotations.forEach(function(ann) {
                         let class_ = ann.link.parent.class;
                         let id_ = '' + ann.link.parent.id;
-                        let children = data.inherited.inheritors[class_][id_];
-                        for(j = 0; j < children.length; j++){
+                        let lineage = data.parents.lineage[class_][id_];
+                        for(j = 0; j < lineage.length; j++){
                             // Unpacking the parent annoations for each image
                             let clone_ann = { ...ann };
-                            clone_ann.link.parent.id = children[j].id;
+                            clone_ann.link.parent.id = lineage[j].id;
                             data.annotations.push(clone_ann);
                         }
                     });

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -1000,7 +1000,7 @@
                         let lineage = data.parents.lineage[class_][id_];
                         for(j = 0; j < lineage.length; j++){
                             // Unpacking the parent annoations for each image
-                            let clone_ann = { ...ann };
+                            let clone_ann = JSON.parse(JSON.stringify(ann));
                             clone_ann.link.parent.id = lineage[j].id;
                             data.annotations.push(clone_ann);
                         }

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -362,7 +362,7 @@
             else if (property === "h") property = "height";
             else if (property === "rot") property = "rotation";
 
-            
+
             var x_symbol = this.get('pixel_size_x_symbol'),
                 z_symbol = this.get('pixel_size_z_symbol');
             z_symbol = z_symbol ? z_symbol : x_symbol // Using x symbol when z not defined
@@ -993,6 +993,16 @@
             var url = WEBINDEX_URL + "api/annotations/?type=tag&limit=1000&" + image_ids;
             $.getJSON(url, function(data){
                 // Map {iid: {id: 'tag'}, {id: 'names'}}
+                if (data.hasOwnProperty('inherited')){
+                    data.inherited.annotations.forEach(function(ann) {
+                        for(j = 0; j < data.inherited.inheritors[ann["id"]].length; j++){
+                            // Unpacking the parent annoations for each image
+                            let clone_ann = { ...ann };
+                            clone_ann.link.parent.id = data.inherited.inheritors[ann["id"]][j].id;
+                            data.annotations.push(clone_ann);
+                        }
+                    });
+                }
                 var imageTags = data.annotations.reduce(function(prev, t){
                     var iid = t.link.parent.id;
                     if (!prev[iid]) {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -990,15 +990,18 @@
             var image_ids = this.map(function(s){return s.get('imageId')})
             image_ids = "image=" + image_ids.join("&image=");
             // TODO: Use /api/ when annotations is supported
-            var url = WEBINDEX_URL + "api/annotations/?type=tag&limit=1000&" + image_ids;
+            var url = WEBINDEX_URL + "api/annotations/?type=tag&parents=yes&limit=1000&" + image_ids;
             $.getJSON(url, function(data){
                 // Map {iid: {id: 'tag'}, {id: 'names'}}
                 if (data.hasOwnProperty('inherited')){
                     data.inherited.annotations.forEach(function(ann) {
-                        for(j = 0; j < data.inherited.inheritors[ann["id"]].length; j++){
+                        let class_ = ann.link.parent.class;
+                        let id_ = '' + ann.link.parent.id;
+                        let children = data.inherited.inheritors[class_][id_];
+                        for(j = 0; j < children.length; j++){
                             // Unpacking the parent annoations for each image
                             let clone_ann = { ...ann };
-                            clone_ann.link.parent.id = data.inherited.inheritors[ann["id"]][j].id;
+                            clone_ann.link.parent.id = children[j].id;
                             data.annotations.push(clone_ann);
                         }
                     });

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -34,16 +34,19 @@ var LabelFromMapsModal = Backbone.View.extend({
         this.isLoading = true;
         $('select', this.el).html("<option>Loading data...</option>");
 
-        var url = WEBINDEX_URL + "api/annotations/?type=map&image=";
+        var url = WEBINDEX_URL + "api/annotations/?type=map&parents=yes&image=";
         url += imageIds.join("&image=");
 
         $.getJSON(url, function(data) {
                 if (data.hasOwnProperty('inherited')){
                     data.inherited.annotations.forEach(function(ann) {
-                        for(j = 0; j < data.inherited.inheritors[ann["id"]].length; j++){
+                        let class_ = ann.link.parent.class;
+                        let id_ = '' + ann.link.parent.id;
+                        let children = data.inherited.inheritors[class_][id_];
+                        for(j = 0; j < children.length; j++){
                             // Unpacking the parent annoations for each image
                             let clone_ann = { ...ann };
-                            clone_ann.link.parent.id = data.inherited.inheritors[ann["id"]][j].id;
+                            clone_ann.link.parent.id = children[j].id;
                             data.annotations.push(clone_ann);
                         }
                     });

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -45,7 +45,7 @@ var LabelFromMapsModal = Backbone.View.extend({
                         let lineage = data.parents.lineage[class_][id_];
                         for(j = 0; j < lineage.length; j++){
                             // Unpacking the parent annoations for each image
-                            let clone_ann = { ...ann };
+                            let clone_ann = JSON.parse(JSON.stringify(ann));
                             clone_ann.link.parent.id = lineage[j].id;
                             data.annotations.push(clone_ann);
                         }

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -39,12 +39,11 @@ var LabelFromMapsModal = Backbone.View.extend({
 
         $.getJSON(url, function(data) {
                 if (data.hasOwnProperty('inherited')){
-                    let inheritors = data.inherited.inheritors;
                     data.inherited.annotations.forEach(function(ann) {
-                        for(j = 0; j < inheritors[ann["id"]].length; j++){
+                        for(j = 0; j < data.inherited.inheritors[ann["id"]].length; j++){
                             // Unpacking the parent annoations for each image
-                            var clone_ann = { ...ann };
-                            clone_ann.link.parent.id = inheritors[ann["id"]][j].id;
+                            let clone_ann = { ...ann };
+                            clone_ann.link.parent.id = data.inherited.inheritors[ann["id"]][j].id;
                             data.annotations.push(clone_ann);
                         }
                     });

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -38,6 +38,17 @@ var LabelFromMapsModal = Backbone.View.extend({
         url += imageIds.join("&image=");
 
         $.getJSON(url, function(data) {
+                if (data.hasOwnProperty('inherited')){
+                    let inheritors = data.inherited.inheritors;
+                    data.inherited.annotations.forEach(function(ann) {
+                        for(j = 0; j < inheritors[ann["id"]].length; j++){
+                            // Unpacking the parent annoations for each image
+                            var clone_ann = { ...ann };
+                            clone_ann.link.parent.id = inheritors[ann["id"]][j].id;
+                            data.annotations.push(clone_ann);
+                        }
+                    });
+                }
                 this.isLoading = false;
                 this.annotations = data.annotations;
                 this.render();
@@ -150,7 +161,7 @@ var LabelFromMapsModal = Backbone.View.extend({
             }
         }
         keyList.sort(function(a, b) {
-            return (a.toUpperCase() < b.toUpperCase()) ? -1 : 1; 
+            return (a.toUpperCase() < b.toUpperCase()) ? -1 : 1;
         });
 
         var html = keyList.map(function(key) {

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -34,19 +34,19 @@ var LabelFromMapsModal = Backbone.View.extend({
         this.isLoading = true;
         $('select', this.el).html("<option>Loading data...</option>");
 
-        var url = WEBINDEX_URL + "api/annotations/?type=map&parents=yes&image=";
+        var url = WEBINDEX_URL + "api/annotations/?type=map&parents=true&image=";
         url += imageIds.join("&image=");
 
         $.getJSON(url, function(data) {
-                if (data.hasOwnProperty('inherited')){
-                    data.inherited.annotations.forEach(function(ann) {
+                if (data.hasOwnProperty('parents')){
+                    data.parents.annotations.forEach(function(ann) {
                         let class_ = ann.link.parent.class;
                         let id_ = '' + ann.link.parent.id;
-                        let children = data.inherited.inheritors[class_][id_];
-                        for(j = 0; j < children.length; j++){
+                        let lineage = data.parents.lineage[class_][id_];
+                        for(j = 0; j < lineage.length; j++){
                             // Unpacking the parent annoations for each image
                             let clone_ann = { ...ann };
-                            clone_ann.link.parent.id = children[j].id;
+                            clone_ann.link.parent.id = lineage[j].id;
                             data.annotations.push(clone_ann);
                         }
                     });


### PR DESCRIPTION
This PR is at a testing stage and relies on a changed function (`api_annotations`) from omero-web, inside a [parallel PR](https://github.com/ome/omero-web/pull/508).

Inherited annotations are decompressed, and the ann.link.parent is changed to the inheritor object. Like so, all further handling of the annotation is the same. No difference if the annotation was on the current image or on a parent object.

The implementation also checks that the query's result has the inherited annotations.

