### PR TITLE
Escape underscores on template labels

### DIFF
--- a/omero_figure/templates/figure/index.html
+++ b/omero_figure/templates/figure/index.html
@@ -520,8 +520,14 @@
                     <h4>Markdown formatting</h4>
                     <p>
                         You can use "Markdown" syntax to add formatting to plain text. For example,
-                        **this text will be bold** and this *word* will be italic. NB: Links are not
-                        supported for panel labels.
+                        **this text will be bold** and this *word* will be italic. 
+                    </p>
+                    <p>
+                        NB: Links are not supported for panel labels.
+                    </p>
+                    <p>
+                        NB: You can escape a certain character to not be interpreted as Markdown by adding \ in front of the 
+                        character. Ex: "my_string_" is interpreted as "my<i>string</i>" but "my\_string\_" is now interpreted as "my_string_"
                     </p>
 
                     <table class="table">
@@ -531,21 +537,21 @@
                             <th>...this text</th></tr>
                         <tr>
                             <th>BOLD</th>
-                            <td>Use 2 stars for **bold**.</td>
-                            <td>Use 2 stars for <strong>bold</strong>.</td>
+                            <td>**bold** or __bold__</td>
+                            <td><strong>bold</strong> or <strong>bold</strong></td>
                         </tr>
                         <tr>
                             <th>ITALIC</th>
-                            <td>Use 1 star for *italic*.</td>
-                            <td>Use 1 star for <i>italic</i>.</td>
+                            <td>*italic* or _italic_</td>
+                            <td><i>italic</i> or <i>italic</i></td>
                         </tr>
                         <tr>
                             <th>LINKS</th>
-                            <td>Add links with [Link text](http://link_url.com)</td>
-                            <td>Add links with <a href="#">Link text</a></td>
+                            <td>[Link text](http://link_url.com)</td>
+                            <td><a href="#">Link text</a></td>
                         </tr>
                        <!--  <tr><td>You need to use 2 line breaks between paragraphs</td><td></td></tr> -->
-                    </table>
+                    </table>                    
                     <h4>Dynamic properties</h4>
                     <p>
                         The drop-down menu in the 'Add Labels' form allows you to create labels based on Image metadata. 

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -259,7 +259,7 @@
                     // If channel has LUT, make grey (visible on black/white bg)
                     var chColor = c.color.endsWith('lut') ? 'BBBBBB' : c.color;
                     newLabels.push({
-                        'text': c.label,
+                        'text': c.label.replaceAll("_","\\_"),
                         'size': options.size,
                         'position': options.position,
                         'color': options.color || chColor
@@ -277,7 +277,7 @@
                     else text = text + " " + c.label
                 }
             });
-            return text ? text : " ";
+            return text ? text.replaceAll("_","\\_") : " ";
         },
 
         getDeltaT: function() {
@@ -986,7 +986,7 @@
                     if (!prev[iid]) {
                         prev[iid] = {};
                     }
-                    prev[iid][t.id] = t.textValue;
+                    prev[iid][t.id] = t.textValue.replaceAll("_","\\_");
                     return prev;
                 }, {});
                 // Apply tags to panels

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -85,7 +85,7 @@ var LabelFromMapsModal = Backbone.View.extend({
             if (imageKeyValues[iid]) {
                 var labels = imageKeyValues[iid].map(function(value){
                     return {
-                        'text': includeKey ? (key.replaceAll("_","\\_") + ': ' + value.replaceAll("_","\\_")) : value.replaceAll("_","\\_"),
+                        'text': includeKey ? (value[0].replaceAll("_","\\_") + ': ' + value[1].replaceAll("_","\\_")) : value[1].replaceAll("_","\\_"),
                         'size': labelSize,
                         'position': labelPosition,
                         'color': labelColor,

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -80,7 +80,7 @@ var LabelFromMapsModal = Backbone.View.extend({
             if (imageValues[iid]) {
                 var labels = imageValues[iid].map(function(value){
                     return {
-                        'text': includeKey ? (key + ': ' + value) : value,
+                        'text': includeKey ? (key.replaceAll("_","\\_") + ': ' + value.replaceAll("_","\\_")) : value.replaceAll("_","\\_"),
                         'size': labelSize,
                         'position': labelPosition,
                         'color': labelColor,

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -85,7 +85,7 @@ var LabelFromMapsModal = Backbone.View.extend({
             if (imageKeyValues[iid]) {
                 var labels = imageKeyValues[iid].map(function(value){
                     return {
-                        'text': includeKey ? (value[0].replaceAll("_","\\_") + ': ' + value[1].replaceAll("_","\\_")) : value[1].replaceAll("_","\\_"),
+                        'text': includeKey ? (key.replaceAll("_","\\_") + ': ' + value.replaceAll("_","\\_")) : value.replaceAll("_","\\_"),
                         'size': labelSize,
                         'position': labelPosition,
                         'color': labelColor,

--- a/src/js/views/labels_from_maps_modal.js
+++ b/src/js/views/labels_from_maps_modal.js
@@ -80,7 +80,7 @@ var LabelFromMapsModal = Backbone.View.extend({
             if (imageValues[iid]) {
                 var labels = imageValues[iid].map(function(value){
                     return {
-                        'text': includeKey ? (key.replaceAll("_","\\_") + ': ' + value.replaceAll("_","\\_")) : value.replaceAll("_","\\_"),
+                        'text': includeKey ? (value[0].replaceAll("_","\\_") + ': ' + value[1].replaceAll("_","\\_")) : value[1].replaceAll("_","\\_"),
                         'size': labelSize,
                         'position': labelPosition,
                         'color': labelColor,


### PR DESCRIPTION
Fix part of issue #486, related to 

I didn't change much because I think the markdown reading need to be preserved (see PR https://github.com/ome/omero-figure/pull/481#issuecomment-1288570316).

For each label added from a template (tags, channel name and key-values only ; image and dataset name are correctly handled), the underscore is escaped with a backslah ``replaceAll("_", "\\_")``. This enables a correct display of the label in omero.figure and it is compatible with ``Figure-to-pdf.py`` (``_`` and ``\_`` are identically interpretated in the script).

I've also integrated this feature in the PR #528.

