### PR TITLE
Duplicated labels removal

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -252,7 +252,6 @@
                 oldLabKeys.push(lbl_key);
                 labs.push( $.extend(true, {}, lbl));
             }
-
             // ... then add new labels ...
             for (var j=0; j<labels.length; j++) {
                 var lbl = labels[j];
@@ -262,7 +261,6 @@
                     labs.push( $.extend(true, {}, lbl));
                 }
             }
-
             // ... so that we get the changed event triggering OK
             this.save('labels', labs);
         },
@@ -435,6 +433,7 @@
         // labels_map is {labelKey: {size:s, text:t, position:p, color:c}} or {labelKey: false} to delete
         // where labelKey specifies the label to edit. "l.text + '_' + l.size + '_' + l.color + '_' + l.position"
         edit_labels: function(labels_map) {
+            
             var oldLabs = this.get('labels');
             // Need to clone the list of labels...
             var labs = [],

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -243,24 +243,24 @@
             var oldLabs = this.get("labels");
             // Need to clone the list of labels...
             var labs = [];
-            var newLabKey = [];
-            for (var i=0; i<labels.length; i++) {
-                newLabKey.push(this.get_label_key(labels[i]));
-            }
+            var oldLabKeys = [];
 
+            // Keep old labels unchanged...
             for (var i=0; i<oldLabs.length; i++) {
-                lbl = oldLabs[i];
-                lbl_key = this.get_label_key(lbl);
-                // for existing label that matches...
-                if (!newLabKey.includes(lbl_key)) {
-                    // otherwise leave un-edited
-                    labs.push( $.extend(true, {}, lbl));
-                }
+                var lbl = oldLabs[i];
+                var lbl_key = this.get_label_key(lbl);
+                oldLabKeys.push(lbl_key);
+                labs.push( $.extend(true, {}, lbl));
             }
 
             // ... then add new labels ...
             for (var j=0; j<labels.length; j++) {
-                labs.push( $.extend(true, {}, labels[j]) );
+                var lbl = labels[j];
+                var lbl_key = this.get_label_key(lbl);
+                if (!oldLabKeys.includes(lbl_key)) {
+                    // otherwise leave un-edited
+                    labs.push( $.extend(true, {}, lbl));
+                }
             }
 
             // ... so that we get the changed event triggering OK

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -241,24 +241,15 @@
             var oldLabs = this.get("labels");
             // Need to clone the list of labels...
             var labs = [];
-            /*for (var i=0; i<oldLabs.length; i++) {
-                labs.push( $.extend(true, {}, oldLabs[i]) );
-            }*/
-           var newLabKey = []
+            var newLabKey = [];
             for (var i=0; i<labels.length; i++) {
                 newLabKey.push(this.get_label_key(labels[i]));
             }
 
             for (var i=0; i<oldLabs.length; i++) {
                 lbl = oldLabs[i];
-
                 lbl_key = this.get_label_key(lbl);
                 // for existing label that matches...
-                console.log(labels)
-                console.log(lbl)
-                console.log(newLabKey)
-                console.log(lbl_key)
-                console.log(newLabKey.includes(lbl_key))
                 if (!newLabKey.includes(lbl_key)) {
                     // otherwise leave un-edited
                     labs.push( $.extend(true, {}, lbl));
@@ -442,21 +433,19 @@
         // labels_map is {labelKey: {size:s, text:t, position:p, color:c}} or {labelKey: false} to delete
         // where labelKey specifies the label to edit. "l.text + '_' + l.size + '_' + l.color + '_' + l.position"
         edit_labels: function(labels_map) {
-
             var oldLabs = this.get('labels');
             // Need to clone the list of labels...
             var labs = [],
-                lbl, lbl_key, replaced = false;
+                lbl, lbl_key;
             for (var i=0; i<oldLabs.length; i++) {
                 lbl = oldLabs[i];
                 lbl_key = this.get_label_key(lbl);
                 // for existing label that matches...
                 if (labels_map.hasOwnProperty(lbl_key)) {
-                    if (labels_map[lbl_key] && !replaced) {
+                    if (labels_map[lbl_key]) {
                         // replace with the new label
                         lbl = $.extend(true, {}, labels_map[lbl_key]);
                         labs.push( lbl );
-                        replaced = true
                     }
                     // else 'false' are ignored (deleted)
                 } else {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -241,13 +241,35 @@
             var oldLabs = this.get("labels");
             // Need to clone the list of labels...
             var labs = [];
-            for (var i=0; i<oldLabs.length; i++) {
+            /*for (var i=0; i<oldLabs.length; i++) {
                 labs.push( $.extend(true, {}, oldLabs[i]) );
+            }*/
+           var newLabKey = []
+            for (var i=0; i<labels.length; i++) {
+                newLabKey.push(this.get_label_key(labels[i]));
             }
+
+            for (var i=0; i<oldLabs.length; i++) {
+                lbl = oldLabs[i];
+
+                lbl_key = this.get_label_key(lbl);
+                // for existing label that matches...
+                console.log(labels)
+                console.log(lbl)
+                console.log(newLabKey)
+                console.log(lbl_key)
+                console.log(newLabKey.includes(lbl_key))
+                if (!newLabKey.includes(lbl_key)) {
+                    // otherwise leave un-edited
+                    labs.push( $.extend(true, {}, lbl));
+                }
+            }
+
             // ... then add new labels ...
             for (var j=0; j<labels.length; j++) {
                 labs.push( $.extend(true, {}, labels[j]) );
             }
+
             // ... so that we get the changed event triggering OK
             this.save('labels', labs);
         },
@@ -424,16 +446,17 @@
             var oldLabs = this.get('labels');
             // Need to clone the list of labels...
             var labs = [],
-                lbl, lbl_key;
+                lbl, lbl_key, replaced = false;
             for (var i=0; i<oldLabs.length; i++) {
                 lbl = oldLabs[i];
                 lbl_key = this.get_label_key(lbl);
                 // for existing label that matches...
                 if (labels_map.hasOwnProperty(lbl_key)) {
-                    if (labels_map[lbl_key]) {
+                    if (labels_map[lbl_key] && !replaced) {
                         // replace with the new label
                         lbl = $.extend(true, {}, labels_map[lbl_key]);
                         labs.push( lbl );
+                        replaced = true
                     }
                     // else 'false' are ignored (deleted)
                 } else {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -463,16 +463,12 @@
                 }
             }
 
-            // filter unique keys only to remove duplicates
-            var filtered_lbls_map = {}
-            for (var i=0; i<labs.length; i++) {
-                filtered_lbls_map[this.get_label_key(labs[i])] = i
-            }
-        
-            var filtered_lbls = [] 
-            _.each(Object.values(filtered_lbls_map), function(idx){
-                filtered_lbls.push(labs[idx])
-            })
+            // Extract all the keys (even duplicates)
+            var keys = labs.map(lbl => this.get_label_key(lbl));
+
+            // get all unique labels based on filtering keys 
+            //(i.e removing duplicate keys based on the index of the first occurrence of the value)
+            var filtered_lbls = labs.filter((lbl, index) => index == keys.indexOf(this.get_label_key(lbl)));
 
             // ... so that we get the changed event triggering OK
             this.save('labels', filtered_lbls);

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -456,8 +456,20 @@
                     labs.push( lbl );
                 }
             }
+
+            // filter unique keys only to remove duplicates
+            var filtered_lbls_map = {}
+            for (var i=0; i<labs.length; i++) {
+                filtered_lbls_map[this.get_label_key(labs[i])] = i
+            }
+        
+            var filtered_lbls = [] 
+            _.each(Object.values(filtered_lbls_map), function(idx){
+                filtered_lbls.push(labs[idx])
+            })
+
             // ... so that we get the changed event triggering OK
-            this.save('labels', labs);
+            this.save('labels', filtered_lbls);
         },
 
         save_channel: function(cIndex, attr, value) {

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -483,7 +483,6 @@
 
         // Use the label 'key' to specify which labels to update
         handle_label_edit: function(event) {
-
             var $form = $(event.target),
                 label_text = $('.label-text', $form).val(),
                 font_size = $('.font-size', $form).text().trim(),
@@ -497,7 +496,6 @@
 
             var newlbls = {};
             newlbls[key] = new_label;
-
             this.models.forEach(function(m){
                 m.edit_labels(newlbls);
             });
@@ -524,15 +522,25 @@
 
             // Render template for each position and append to $el
             var html = "";
+            var filteredLbls = []
             _.each(positions, function(lbls, p) {
-
                 lbls = _.map(lbls, function(label, key){ return label; });
 
                 var json = {'position':p, 'labels':lbls};
                 if (lbls.length === 0) return;
+                console.log(lbls)
+                lbls.forEach(function(lbl){
+                    filteredLbls.push(lbl)
+                })
+                
                 json.inner_template = self.inner_template;
                 html += self.template(json);
             });
+           
+            this.models.forEach(function(m){
+                m.save('labels', filteredLbls);
+            })
+
             self.$el.append(html);
 
             return this;

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -483,6 +483,7 @@
 
         // Use the label 'key' to specify which labels to update
         handle_label_edit: function(event) {
+
             var $form = $(event.target),
                 label_text = $('.label-text', $form).val(),
                 font_size = $('.font-size', $form).text().trim(),
@@ -496,6 +497,7 @@
 
             var newlbls = {};
             newlbls[key] = new_label;
+
             this.models.forEach(function(m){
                 m.edit_labels(newlbls);
             });
@@ -523,11 +525,11 @@
             // Render template for each position and append to $el
             var html = "";
             _.each(positions, function(lbls, p) {
+
                 lbls = _.map(lbls, function(label, key){ return label; });
 
                 var json = {'position':p, 'labels':lbls};
                 if (lbls.length === 0) return;
-                
                 json.inner_template = self.inner_template;
                 html += self.template(json);
             });

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -522,25 +522,15 @@
 
             // Render template for each position and append to $el
             var html = "";
-            var filteredLbls = []
             _.each(positions, function(lbls, p) {
                 lbls = _.map(lbls, function(label, key){ return label; });
 
                 var json = {'position':p, 'labels':lbls};
                 if (lbls.length === 0) return;
-                console.log(lbls)
-                lbls.forEach(function(lbl){
-                    filteredLbls.push(lbl)
-                })
                 
                 json.inner_template = self.inner_template;
                 html += self.template(json);
             });
-           
-            this.models.forEach(function(m){
-                m.save('labels', filteredLbls);
-            })
-
             self.$el.append(html);
 
             return this;


### PR DESCRIPTION
Fix issue #502 by removing duplicate labels.
1. If a new label is added, the duplicated label is filtered before adding it to the figure
2. If an existing label is edited, the duplicated label is filtered after adding it to the figure.