### PR TITLE
Fix missing pixel_size_z_symbol in Figure_To_Pdf.py

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1247,6 +1247,7 @@ class FigureExport(object):
                         z_symbol = panel.get('pixel_size_z_symbol')
                         if pixel_size_z is None:
                             pixel_size_z = 0
+                        if z_symbol is None:
                             z_symbol = "\xB5m"
 
                         if ("z_projection" in panel.keys()


### PR DESCRIPTION
Fixes the issue reported at https://github.com/ome/omero-figure/pull/521#pullrequestreview-1746222892
and described at https://github.com/ome/omero-figure/pull/521#issuecomment-1824264581

To test:
Try to export that same figure (or create another one where a panel is missing `pixel_size_z_symbol`, possibly by editing JSON etc).

cc @pwalczysko 