### PR TITLE
Handle image loading errors

### DIFF
--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -121,15 +121,19 @@ def img_data_json(request, image_id, conn=None, **kwargs):
 
     if units_support:
         # Add extra parameters with units data
+        if 'pixel_size' not in rv:
+            rv['pixel_size'] = {}
         # NB ['pixel_size']['x'] will have size in MICROMETER
         px = image.getPrimaryPixels().getPhysicalSizeX()
-        rv['pixel_size']['valueX'] = px.getValue()
-        rv['pixel_size']['symbolX'] = px.getSymbol()
-        rv['pixel_size']['unitX'] = str(px.getUnit())
+        if px is not None:
+            rv['pixel_size']['valueX'] = px.getValue()
+            rv['pixel_size']['symbolX'] = px.getSymbol()
+            rv['pixel_size']['unitX'] = str(px.getUnit())
         py = image.getPrimaryPixels().getPhysicalSizeY()
-        rv['pixel_size']['valueY'] = py.getValue()
-        rv['pixel_size']['symbolY'] = py.getSymbol()
-        rv['pixel_size']['unitY'] = str(py.getUnit())
+        if py is not None:
+            rv['pixel_size']['valueY'] = py.getValue()
+            rv['pixel_size']['symbolY'] = py.getSymbol()
+            rv['pixel_size']['unitY'] = str(py.getUnit())
         pz = image.getPrimaryPixels().getPhysicalSizeZ()
         if pz is not None:
             rv['pixel_size']['valueZ'] = pz.getValue()

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -459,6 +459,11 @@
                 dataType: dataType,
                 // work with the response
                 success: function( data ) {
+                    if (data.Exception) {
+                        // If something went wrong, show error and don't add to figure
+                        alert(`Image loading from ${imgDataUrl} included an Error: ${data.Exception}`);
+                        return;
+                    }
 
                     self.set('loading_count', self.get('loading_count') - 1);
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -459,9 +459,10 @@
                 dataType: dataType,
                 // work with the response
                 success: function( data ) {
-                    if (data.Exception) {
+                    if (data.Exception || data.ConcurrencyException) {
                         // If something went wrong, show error and don't add to figure
-                        alert(`Image loading from ${imgDataUrl} included an Error: ${data.Exception}`);
+                        message = data.Exception || "ConcurrencyException"
+                        alert(`Image loading from ${imgDataUrl} included an Error: ${message}`);
                         return;
                     }
 


### PR DESCRIPTION
See https://forum.image.sc/t/misleading-error-message-in-omero-figure/68642

Also fixes #347.

This aims to improve the handling of errors when adding Images to Figures.
We try to avoid the errors reported on that issue, so that Images can load OK with missing pixel size info. 
Also, if there is any `Exception` message coming from https://github.com/ome/omero-web/blob/604d5279c96909a6862e4b1fc67de4f0a8699298/omeroweb/webgateway/marshal.py#L178 then we display it and don't try to add the Image to the figure.

To test:
One way to trigger one of the exception on #347 is to use the script below to unset pixelsize-Y. They should now be added to OMERO.figure OK (no error).

Invalid images (failed imports etc) should now give an appropriate error and NOT be added to the figure, but I don't know an easy way to generate such images?

```
import argparse
import sys

import omero
import omero.clients
from omero.model.enums import UnitsLength
from omero.cli import cli_login
from omero.gateway import BlitzGateway

def set_pixels_size(conn, image):

    pixelSize = omero.model.LengthI(5, UnitsLength.MICROMETER)
    pixels = image.getPrimaryPixels()._obj
    pixels.setPhysicalSizeX(pixelSize)
    pixels.setPhysicalSizeY(None)
    pixels.setPhysicalSizeZ(pixelSize)
    conn.getUpdateService().saveObject(pixels)

def main(argv):
    parser = argparse.ArgumentParser()
    parser.add_argument('image', help='Image ID')
    args = parser.parse_args(argv)

    with cli_login() as cli:
        conn = BlitzGateway(client_obj=cli._client)
        image = conn.getObject("Image", args.image)
        set_pixels_size(conn, image)

if __name__ == '__main__':  
    main(sys.argv[1:])
```