### PR TITLE
Don't swap width/height when cropping page

### DIFF
--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -156,7 +156,7 @@
                 h_mm = Math.round(h_pixels * 25.4 / dpi);
             }
 
-            if (orientation == 'horizontal' && size != 'mm') {
+            if (orientation == 'horizontal' && size != 'mm' && size != 'crop') {
                 var tmp = w_mm; w_mm = h_mm; h_mm = tmp;
                 tmp = w_pixels; w_pixels = h_pixels; h_pixels = tmp;
             }


### PR DESCRIPTION
Fixes #539 

To test:

 - In page layout, choose "horizontal" page orientation
 - Arrange some panels in a non-square layout (so you can tell the difference between width and height)
 - Now in page layout again, choose "crop" to panels
 - Cropped page should match the panels (not swap width/height as in bug on issue above)