### PR TITLE
Integration tests: call pytest directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,11 @@
 # Version: 1.0
 
 import os
-import sys
 from setuptools.command.build_py import build_py
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 from setuptools.command.develop import develop
 from setuptools import setup, find_packages
-from setuptools.command.test import test as test_command
 import omero_figure.utils as utils
 
 VERSION = utils.__version__
@@ -36,73 +34,6 @@ DESCRIPTION = "OMERO figure creation app"
 AUTHOR = "The Open Microscopy Team"
 LICENSE = "AGPL-3.0"
 HOMEPAGE = "https://github.com/ome/omero-figure"
-
-
-class PyTest(test_command):
-    user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-string=', 'k', "filter tests by string"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
-
-    def initialize_options(self):
-        test_command.initialize_options(self)
-        self.test_pythonpath = None
-        self.test_string = None
-        self.test_marker = None
-        self.test_path = 'test'
-        self.test_failfast = False
-        self.test_quiet = False
-        self.test_verbose = False
-        self.test_no_capture = False
-        self.junitxml = None
-        self.pdb = False
-        self.test_ice_config = None
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = [self.test_path]
-        if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
-        if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
-        if self.test_failfast:
-            self.test_args.extend(['-x'])
-        if self.test_verbose:
-            self.test_args.extend(['-v'])
-        if self.test_quiet:
-            self.test_args.extend(['-q'])
-        if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
-        if self.pdb:
-            self.test_args.extend(['--pdb'])
-        self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
-
-    def run_tests(self):
-        if self.test_pythonpath is not None:
-            sys.path.insert(0, self.test_pythonpath)
-
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
-
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
-
-        import django
-        if django.VERSION > (1, 7):
-            django.setup()
 
 
 def require_npm(command, strict=False):
@@ -161,7 +92,6 @@ setup(name="omero-figure",
         'install': require_npm(install),
         'sdist': require_npm(sdist, True),
         'develop': require_npm(develop),
-        'test': PyTest
       },
       tests_require=['pytest', 'numpy'],
       )


### PR DESCRIPTION
Depends on https://github.com/ome/omero-test-infra/pull/68

These changes drop the custom `PyTest` test command and use the development test-infra branch to call `pytest` directly.