### PR TITLE
Enable save button when update ID

### DIFF
--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -317,6 +317,7 @@
             sel.forEach(function(p) {
                 p.setId(self.newImg);
             });
+            this.model.set('unsaved', true);
 
         },
 


### PR DESCRIPTION
Hello @will-moore, 

I noticed that the feature ``Edit ID`` doesn't release the ``save`` button. 
Thus, it is not possible to save the figure and, if I close it without doing anything else, the ID edition is not taken into account.

I simply turn on the boolean of unsaved changes to release the button, so that we can click on it to save the figure.

Rémy.

Edit: doing ``ctrl``+``S`` with keybord worked well, even if the button was disabled