### PR TITLE
Fix cropping of panel labels and float usage for shape labels

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -564,7 +564,7 @@ class ShapeToPilExport(ShapeExport):
             return
         r, g, b, a = self.get_rgba_int(shape['strokeColor'])
         # bump up alpha a bit to make text more readable
-        rgba = (r, g, b, 128 + a / 2)
+        rgba = (r, g, b, int(128 + a / 2))
         font_name = "FreeSans.ttf"
         from omero.gateway import THISPATH
         path_to_font = os.path.join(THISPATH, "pilfonts", font_name)
@@ -576,7 +576,7 @@ class ShapeToPilExport(ShapeExport):
         box = font.getbbox(text)
         width = box[2] - box[0]
         height = box[3] - box[1]
-        xy = (center[0] - width / 2.0, center[1] - height / 2.0)
+        xy = (int(center[0] - width / 2.0), int(center[1] - height / 2.0))
         self.draw.text(xy, text, fill=rgba, font=font)
 
     def draw_arrow(self, shape):
@@ -2275,7 +2275,7 @@ class TiffExport(FigureExport):
             box = font.getbbox(t['text'])
             txt_w = box[2] - box[0]
             txt_h = box[3] - box[1]
-            textdraw.text((w, 0), t['text'], font=font, fill=rgb)
+            textdraw.text((w, -box[1]), t['text'], font=font, fill=rgb)
             w += txt_w
         return temp_label
 


### PR DESCRIPTION
Since we updated to use `x, y, x2, y2 = font.getbbox(text)` to get the height of text, the labels that are pasted on to the temporary canvas of that height are cropped at the bottom. We have removed the margin by using `height = x2 - x` but since the pasting at `x = 0` actually pastes *with* the margin (so the canvas is not big enough).

If we set the temporary canvas to grey for each label for debugging, we can see this effect more clearly:

![Screenshot 2024-03-12 at 13 09 47](https://github.com/ome/omero-figure/assets/900055/dcc899ab-5df7-441a-b4ac-9e3ae15070d5)

 In order to paste right at the top of the temp canvas (without the margin), we need to set the x coordinate to be negative margin:

This also positions the text the same as in the original figure:

![Screenshot 2024-03-12 at 13 19 51](https://github.com/ome/omero-figure/assets/900055/97cf53c8-f9d7-456a-915b-333ffffe66ed)

Original figure:

![Screenshot 2024-03-12 at 13 21 33](https://github.com/ome/omero-figure/assets/900055/54e7a6b9-022a-437d-98a6-9a108134460d)


NB: I also tested the export of *shape* labels (shown in 2nd screenshot above) which didn't need a fix to the `font.getbbox()` logic, but did need some casting of floats to ints. Shape labels aren't supported by vanilla OMERO.figure - I think they were added to the export script by Glencoe, so the only way to test that is to add `"text": "some text"` to the Shape JSON. cc @knabar 

To test:

 - Add labels to a Figure (including with markdown italics and bold) and export as TIFF - check that they are not cropped in the TIFF