### PR TITLE
Inset feature

### DIFF
--- a/src/css/figure.css
+++ b/src/css/figure.css
@@ -50,6 +50,14 @@
         font-size: 1.0rem;
     }
 
+    /* e.g. Inset form */
+    .form-inline h5 {
+        display: inline-flex;
+        margin-right: 10px;
+        vertical-align: middle;
+        margin-bottom: 0;
+    }
+
     header {
         background: gray;
         height: 30px;
@@ -1004,6 +1012,7 @@
     }
 
     .colorpicker span,
+    .inset-color span:first-child,
     .label-color span:first-child,
     .shape-color span:first-child {
         border: solid 1px #bbb;

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -87,7 +87,7 @@
                     'paper_height': data.paper_height,
                     'width_mm': data.width_mm,
                     'height_mm': data.height_mm,
-                    'page_size': data.page_size || 'letter',
+                    'page_size': data.page_size || 'A4',
                     'page_count': data.page_count,
                     'paper_spacing': data.paper_spacing,
                     'page_col_count': data.page_col_count,

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -45,6 +45,12 @@
         initialize: function() {
             this.panels = new PanelList();      //this.get("shapes"));
 
+            // listen for new Panels added so we can pass in a reference
+            // to this figureModel...
+            this.panels.on('add', (panel) => {
+                panel.setFigureModel(this);
+            });
+
             // wrap selection notification in a 'debounce', so that many rapid
             // selection changes only trigger a single re-rendering 
             this.notifySelectionChange = _.debounce( this.notifySelectionChange, 10);

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -69,9 +69,8 @@
         handleShapesChange(panel) {
             // The ROI rectangle has been updated on another panel - update viewport to match...
             // Update zoom/panel but don't trigger zoomPanUpdated or we could get
-            // recursive feedback!?
+            // recursive feedback
             var insetRoiId = this.get('insetRoiId');
-            console.log("handleShapesChange insetRoiId", insetRoiId, "coming from shapes", panel.get("shapes"));
             if (!insetRoiId) return;
 
             this.silenceTriggers = true;
@@ -79,8 +78,6 @@
             // find Rectangle from panel that corresponds to this panel
             // TODO: use shape.insetRoiId for storing the ID, instead of the shape's actual id
             let rect = (panel.get("shapes") || []).find(shape => shape.id == insetRoiId);
-            console.log('handleShapesChange, rect', rect);
-
             if (rect) {
                 this.cropToRoi(rect);
             }
@@ -89,6 +86,8 @@
         },
 
         handleZoomPanChange(panel) {
+            // An inset panel has zoomed/panned. If we have corresponding inset Rectangle
+            // then update it accordingly...
             var insetRoiId = panel.get('insetRoiId');
             if (!insetRoiId) return;
             // find Rectangles that have insetRoiId...

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -78,7 +78,7 @@
 
             // find Rectangle from panel that corresponds to this panel
             // TODO: use shape.insetRoiId for storing the ID, instead of the shape's actual id
-            let rect = panel.get("shapes").find(shape => shape.id == insetRoiId);
+            let rect = (panel.get("shapes") || []).find(shape => shape.id == insetRoiId);
             console.log('handleShapesChange, rect', rect);
 
             if (rect) {

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -76,7 +76,6 @@
             this.silenceTriggers = true;
 
             // find Rectangle from panel that corresponds to this panel
-            // TODO: use shape.insetRoiId for storing the ID, instead of the shape's actual id
             let rect = (panel.get("shapes") || []).find(shape => shape.id == insetRoiId);
             if (rect) {
                 this.cropToRoi(rect);

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -39,7 +39,7 @@
 
         initialize: function() {
             // listen for changes to the viewport...
-            this.on("change:zoom change:dx change:dy change:width change:height", (panel) => {
+            this.on("change:zoom change:dx change:dy change:width change:height change:rotation", (panel) => {
                 // if this panel has 'insetRoiId' it is an "inset" panel so we need to
                 // notify other panels that contain the corresponding ROI (rectangle)
                 if (this.get('insetRoiId') && this.figureModel) {
@@ -690,7 +690,10 @@
 
             var toSet = { 'width': newW, 'height': newH, 'dx': dx, 'dy': dy, 'zoom': zoom };
             var rotation = coords.rotation || 0;
+            // if the rectangle/viewport is rotated clockwise, the image within the
+            // viewport is rotated anti-clockwise
             if (!isNaN(rotation)) {
+                rotation = -(rotation - 360);
                 toSet.rotation = rotation;
             }
             this.save(toSet);
@@ -702,6 +705,12 @@
             dx = dx !== undefined ? dx : this.get('dx');
             dy = dy !== undefined ? dy : this.get('dy');
             var rotation = this.get('rotation');
+            if (isNaN(rotation)) {
+                rotation = 0;
+            };
+            // if we have rotated the panel clockwise within the viewport 
+            // it's as if the viewport rectangle has rotated anti-clockwise
+            rotation = 360 - rotation;
 
             var width = this.get('width'),
                 height = this.get('height'),

--- a/src/js/shapeEditorTest.js
+++ b/src/js/shapeEditorTest.js
@@ -166,17 +166,17 @@ $(function() {
         } else {
            $("input[name='strokeColor']").removeProp('checked');
         }
-        var fillColor = shapeManager.getFillColor();
-        if (fillColor) {
-          $("input[name='fillColor'][value='" + fillColor + "']").prop('checked', 'checked');
-        } else {
-           $("input[name='fillColor']").removeProp('checked');
-        }
+        // var fillColor = shapeManager.getFillColor();
+        // if (fillColor) {
+        //   $("input[name='fillColor'][value='" + fillColor + "']").prop('checked', 'checked');
+        // } else {
+        //    $("input[name='fillColor']").removeProp('checked');
+        // }
         var strokeWidth = shapeManager.getStrokeWidth() || 1;
         $("select[name='strokeWidth']").val(strokeWidth);
 
-        var fillOpacity = shapeManager.getFillOpacity() || 0.01;
-        $("select[name='fillOpacity']").val(fillOpacity);
+        // var fillOpacity = shapeManager.getFillOpacity() || 0.01;
+        // $("select[name='fillOpacity']").val(fillOpacity);
     });
 
     $("#shapesCanvas").bind("change:shape", function(event, shapes){

--- a/src/js/shapeEditorTest.js
+++ b/src/js/shapeEditorTest.js
@@ -200,11 +200,18 @@ $(function() {
                                "strokeWidth": 4});
 
     shapeManager.addShapeJson({"id": 1234,
+                               "rotation": 45,
                                "type": "Rectangle",
                                "strokeColor": "#ff00ff",
                                "strokeWidth": 6,
                                "x": 200, "y": 150,
                                "width": 125, "height": 150});
+
+    shapeManager.addShapeJson({"type": "Rectangle",
+                               "strokeColor": "#ffffff",
+                               "strokeWidth": 3,
+                               "x": 50, "y": 300,
+                               "width": 50, "height": 100});
 
     shapeManager.addShapeJson({"type": "Ellipse",
                                "x": 200, "y": 150,

--- a/src/js/shape_editor/rect.js
+++ b/src/js/shape_editor/rect.js
@@ -51,6 +51,7 @@ var Rect = function Rect(options) {
   if (options.zoom) {
     this._zoomFraction = options.zoom / 100;
   }
+  this._rotation = options.rotation || 0;
   this.handle_wh = 6;
 
   this.element = this.paper.rect();
@@ -104,6 +105,7 @@ Rect.prototype.toJson = function toJson() {
     'area': this._width * this._height,
     strokeWidth: this._strokeWidth,
     strokeColor: this._strokeColor,
+    rotation: this._rotation,
   };
   if (this._id) {
     rv.id = this._id;
@@ -258,6 +260,8 @@ Rect.prototype.drawShape = function drawShape() {
     "stroke-width": lineW,
   });
 
+  this.element.transform("r" + this._rotation + "," + (x + (w/2)) + "," + (y + (h/2)));
+
   if (this.isSelected()) {
     this.handles.show().toFront();
   } else {
@@ -273,6 +277,7 @@ Rect.prototype.drawShape = function drawShape() {
     hx = handleIds[h_id][0];
     hy = handleIds[h_id][1];
     hnd.attr({ x: hx - this.handle_wh / 2, y: hy - this.handle_wh / 2 });
+    hnd.transform("r" + this._rotation + "," + (x + (w/2)) + "," + (y + (h/2)));
   }
 };
 
@@ -397,6 +402,9 @@ Rect.prototype.createHandles = function createHandles() {
   // var _stop_event_propagation = function(e) {
   //     e.stopImmediatePropagation();
   // }
+  let cx = handleIds['n'][0];
+  let cy = handleIds['e'][1];
+
   for (var key in handleIds) {
     var hx = handleIds[key][0];
     var hy = handleIds[key][1];
@@ -407,7 +415,8 @@ Rect.prototype.createHandles = function createHandles() {
         self.handle_wh,
         self.handle_wh
       )
-      .attr(handle_attrs);
+      .attr(handle_attrs)
+      .rotate(self._rotation, cx, cy);
     handle.attr({ cursor: key + "-resize" }); // css, E.g. ne-resize
     handle.h_id = key;
     handle.rect = self;

--- a/src/js/shape_editor/rect.js
+++ b/src/js/shape_editor/rect.js
@@ -301,6 +301,22 @@ Rect.prototype.getHandleCoords = function getHandleCoords() {
   return handleIds;
 };
 
+function correct_rotation(dx, dy, rotation) {
+  if (dx === 0 && dy === 0) {
+      return {x: dx, y: dy};
+  }
+  var length = Math.sqrt(dx * dx + dy * dy),
+      ang1 = Math.atan(dy/dx);
+  if (dx < 0) {
+      ang1 = Math.PI + ang1;
+  }
+  var angr = rotation * (Math.PI/180),  // deg -> rad
+      ang2 = ang1 - angr;
+  dx = Math.cos(ang2) * length;
+  dy = Math.sin(ang2) * length;
+  return {x: dx, y: dy};
+}
+
 // ---- Create Handles -----
 Rect.prototype.createHandles = function createHandles() {
   var self = this,
@@ -320,6 +336,12 @@ Rect.prototype.createHandles = function createHandles() {
     return function (dx, dy, mouseX, mouseY, event) {
       dx = dx / self._zoomFraction;
       dy = dy / self._zoomFraction;
+      // need to handle rotation...
+      if (self._rotation != 0) {
+        let xy = correct_rotation(dx, dy, self._rotation);
+        dx = xy.x;
+        dy = xy.y;
+      }
 
       // If drag on corner handle, retain aspect ratio. dx/dy = aspect
       var keep_ratio = self.fixed_ratio || event.shiftKey;

--- a/src/js/shape_editor/shape_manager.js
+++ b/src/js/shape_editor/shape_manager.js
@@ -418,6 +418,7 @@ ShapeManager.prototype.createShapeJson = function createShapeJson(jsonShape) {
     options.width = s.width;
     options.height = s.height;
     options.area = s.width * s.height;
+    options.rotation = s.rotation;
     newShape = new Rect(options);
   } else if (s.type === "Line") {
     options.x1 = s.x1;

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -24,7 +24,8 @@
         showExportAsJsonModal,
         showModal,
         hideModals,
-        hideModal} from "./util";
+        hideModal,
+        updateRoiIds} from "./util";
 
     // This extends Backbone to support keyboardEvents
     backboneMousetrap(_, Backbone, Mousetrap);
@@ -645,8 +646,11 @@
             // apply offset to clipboard data & paste
             // NB: we are modifying the list that is in the clipboard
             _.each(clipboard_panels, function(m) {
+                m = JSON.parse(JSON.stringify(m))
                 m.x = m.x + offset_x;
                 m.y = m.y + offset_y;
+                // we want duplicated panels to have unique ROI IDs 
+                m = updateRoiIds(m);
                 self.model.panels.create(m);
             });
             // only pasted panels are selected - simply trigger...

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -572,6 +572,8 @@
             var cd = [];
             s.forEach(function(m) {
                 var copy = m.toJSON();
+                // deep copy (e.g. includes shapes)
+                copy = JSON.parse(JSON.stringify(copy));
                 delete copy.id;
                 cd.push(copy);
             });
@@ -645,12 +647,11 @@
 
             // apply offset to clipboard data & paste
             // NB: we are modifying the list that is in the clipboard
+            clipboard_panels = updateRoiIds(clipboard_panels);
+
             _.each(clipboard_panels, function(m) {
-                m = JSON.parse(JSON.stringify(m))
                 m.x = m.x + offset_x;
                 m.y = m.y + offset_y;
-                // we want duplicated panels to have unique ROI IDs 
-                m = updateRoiIds(m);
                 self.model.panels.create(m);
             });
             // only pasted panels are selected - simply trigger...

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -119,14 +119,6 @@
         createInset: function() {
             let selected = this.model.getSelected();
 
-            // get bounding box of selected panels...
-            let minX = selected.reduce((prev, panel) => Math.min(panel.get('x'), prev), Infinity);
-            let maxX = selected.reduce((prev, panel) => Math.max(panel.get('x') + panel.get('width'), prev), -Infinity);
-            let minY = selected.reduce((prev, panel) => Math.min(panel.get('y'), prev), Infinity);
-            let maxY = selected.reduce((prev, panel) => Math.max(panel.get('y') + panel.get('height'), prev), -Infinity);
-            let selWidth = maxX - minX;
-            let selHeight = maxY - minY;
-
             selected.forEach(panel => {
                 let randomId = getRandomId();
                 // Add Rectangle (square) in centre of viewport
@@ -146,6 +138,7 @@
                     width: rectSize,
                     height: rectSize,
                     id: randomId,
+                    rotation: vp.rotation || 0,
                 }
                 panel.add_shapes([rect]);
 

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -151,6 +151,11 @@
                 // Create duplicate panels
                 let panelJson = panel.toJSON();
 
+                // want to make sure new panel is square
+                let maxSide = Math.min(panelJson.width, panelJson.height);
+                panelJson.width = maxSide;
+                panelJson.height = maxSide;
+
                 if (selWidth > selHeight) {
                     panelJson.y = panelJson.y + 1.1 * panelJson.height;
                 } else {

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -134,8 +134,9 @@
                 let minSide = Math.min(vp.width, vp.height);
                 // Square is 1/3 size of the viewport
                 let rectSize = minSide / 3;
-                var color = $('button.shape-color span:first', this.$el).attr('data-color');
-                var strokeWidth = parseFloat($('button.line-width span:first', this.$el).attr('data-line-width'));
+                var color = $('.inset-color span:first', this.$el).attr('data-color');
+                var position = $('.label-position i:first', this.$el).attr('data-position');
+                var strokeWidth = parseFloat($('button.inset-width span:first', this.$el).attr('data-line-width'));
                 let rect = {
                     type: "Rectangle",
                     strokeWidth,
@@ -156,8 +157,12 @@
                 panelJson.width = maxSide;
                 panelJson.height = maxSide;
 
-                if (selWidth > selHeight) {
+                if (position == "bottom") {
                     panelJson.y = panelJson.y + 1.1 * panel.get("height");
+                } else if (position == "left") {
+                    panelJson.x = panelJson.x - (1.1 * panelJson.width);
+                } else if (position == "top") {
+                    panelJson.y = panelJson.y - (1.1 * panelJson.height);
                 } else {
                     panelJson.x = panelJson.x + 1.1 * panel.get("width");
                 }

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -157,9 +157,9 @@
                 panelJson.height = maxSide;
 
                 if (selWidth > selHeight) {
-                    panelJson.y = panelJson.y + 1.1 * panelJson.height;
+                    panelJson.y = panelJson.y + 1.1 * panel.get("height");
                 } else {
-                    panelJson.x = panelJson.x + 1.1 * panelJson.width;
+                    panelJson.x = panelJson.x + 1.1 * panel.get("width");
                 }
                 // cropped to match new Rectangle
                 let orig_width = panelJson.orig_width;

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -7,7 +7,7 @@
     import _ from "underscore";
     import $ from "jquery";
 
-    import {figureConfirmDialog, showModal} from "./util";
+    import {figureConfirmDialog, showModal, getRandomId} from "./util";
     import FigureColorPicker from "../views/colorpicker";
 
     import FigureModel from "../models/figure_model";
@@ -128,7 +128,7 @@
             let selHeight = maxY - minY;
 
             selected.forEach(panel => {
-                let randomId = parseInt(Math.random() * 10000000000);
+                let randomId = getRandomId();
                 // Add Rectangle (square) in centre of viewport
                 let vp = panel.getViewportAsRect();
                 let minSide = Math.min(vp.width, vp.height);

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1008,10 +1008,14 @@
                 rect = clipboard_data.CROP;
             } else if ('SHAPES' in clipboard_data){
                 // Look for first Rectangle in SHAPES
-                shapeJson = clipboard_data.SHAPES;
+                var shapeJson = clipboard_data.SHAPES;
                 shapeJson.forEach(function(shape) {
                     if (!rect && shape.type === "Rectangle") {
-                        rect = {x: shape.x, y: shape.y, width: shape.width, height: shape.height};
+                        rect = {
+                            x: shape.x, y: shape.y,
+                            width: shape.width, height: shape.height,
+                            rotation: shape.rotation
+                        };
                     }
                 });
                 if (!rect) {

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -260,3 +260,30 @@ export async function getJson (url) {
     let cors_headers = { mode: 'cors', credentials: 'include' };
     return fetch(url, cors_headers).then(rsp => rsp.json());
 }
+
+export const RANDOM_NUMBER_RANGE = 100000000;
+
+export function getRandomId() {
+    return parseInt(Math.random() * RANDOM_NUMBER_RANGE);
+}
+
+export function newIdFromRandomId(oldId) {
+    return parseInt((oldId * Math.PI) % RANDOM_NUMBER_RANGE);
+}
+
+export function updateRoiIds(panelJson) {
+    // used when copy/pasting panel to duplicate it, we want to avoid duplicate ROI IDs
+    // so we update ROI IDs, and the corresponding `insetRoiId` on any inset panels
+
+    if (panelJson.insetRoiId) {
+        panelJson.insetRoiId = newIdFromRandomId(panelJson.insetRoiId);
+    }
+    if (panelJson.shapes) {
+        panelJson.shapes.forEach(shape => {
+            if (shape.id) {
+                shape.id = newIdFromRandomId(shape.id);
+            }
+        });
+    }
+    return panelJson;
+}

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -271,19 +271,46 @@ export function newIdFromRandomId(oldId) {
     return parseInt((oldId * Math.PI) % RANDOM_NUMBER_RANGE);
 }
 
-export function updateRoiIds(panelJson) {
-    // used when copy/pasting panel to duplicate it, we want to avoid duplicate ROI IDs
-    // so we update ROI IDs, and the corresponding `insetRoiId` on any inset panels
+export function updateRoiIds(panelsJson) {
+    // If we copy and paste an inset panel AND it's corresponding panel with Rect,
+    // we don't want changes in viewport/Rect to trigger changes in the panels they
+    // were copied from - so we update IDs...
 
-    if (panelJson.insetRoiId) {
-        panelJson.insetRoiId = newIdFromRandomId(panelJson.insetRoiId);
-    }
-    if (panelJson.shapes) {
-        panelJson.shapes.forEach(shape => {
-            if (shape.id) {
-                shape.id = newIdFromRandomId(shape.id);
-            }
-        });
-    }
-    return panelJson;
+    // But, if we ONLY copy/paste a panel containing an Inset Rect, keep the insetRoiId
+    // so that it continues to sync with the inset panel.
+    // And if we ONLY copy/paste an inset panel, keep the insetRoiId so that it stays
+    // in sync with corresponding Rect
+
+    let insetIdsFromPanels = panelsJson.map(panel => panel.insetRoiId).filter(Boolean);
+    let insetIdsFromShapes = [];
+    panelsJson.forEach(panel => {
+        if (panel.shapes) {
+            panel.shapes.forEach(shape => {
+                if (shape.id) {
+                    insetIdsFromShapes.push(shape.id);
+                }
+            });
+        }
+    });
+    console.log('insetIdsFromPanels', insetIdsFromPanels);
+    console.log('insetIdsFromShapes', insetIdsFromShapes);
+
+    let idsToUpdate = insetIdsFromPanels.filter(roiId => insetIdsFromShapes.includes(roiId));
+
+
+    let updatedPanels = panelsJson.map(panelJson => {
+        if (idsToUpdate.includes(panelJson.insetRoiId)) {
+            panelJson.insetRoiId = newIdFromRandomId(panelJson.insetRoiId);
+        }
+        if (panelJson.shapes) {
+            panelJson.shapes.forEach(shape => {
+                if (idsToUpdate.includes(shape.id)) {
+                    shape.id = newIdFromRandomId(shape.id);
+                }
+            });
+        }
+        return panelJson;
+    });
+
+    return updatedPanels;
 }

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -281,6 +281,7 @@ export function updateRoiIds(panelsJson) {
     // And if we ONLY copy/paste an inset panel, keep the insetRoiId so that it stays
     // in sync with corresponding Rect
 
+    // Find the insetRoiIds that are in BOTH panels and shapes
     let insetIdsFromPanels = panelsJson.map(panel => panel.insetRoiId).filter(Boolean);
     let insetIdsFromShapes = [];
     panelsJson.forEach(panel => {
@@ -292,12 +293,9 @@ export function updateRoiIds(panelsJson) {
             });
         }
     });
-    console.log('insetIdsFromPanels', insetIdsFromPanels);
-    console.log('insetIdsFromShapes', insetIdsFromShapes);
-
     let idsToUpdate = insetIdsFromPanels.filter(roiId => insetIdsFromShapes.includes(roiId));
 
-
+    // Update the IDs
     let updatedPanels = panelsJson.map(panelJson => {
         if (idsToUpdate.includes(panelJson.insetRoiId)) {
             panelJson.insetRoiId = newIdFromRandomId(panelJson.insetRoiId);

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -102,7 +102,6 @@
             <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu">
-            <li role="presentation" class="dropdown-header">Inside Corners</li>
             <!-- NB: dropdown_icon is picked on choosing dropdown, replaces icon in button above -->
             <li><a class="dropdown-item" href="#">
                 <i data-position="left" class="bi-box-arrow-left dropdown_icon"></i> Left</a>

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -93,7 +93,8 @@
 </form>
 
 <form class="form-inline clearfix" role="form" style="margin-top: 10px;">
-    <button class="create_inset btn btn-sm btn-outline-secondary">
+    <button class="create_inset btn btn-sm btn-outline-secondary"
+        title="Create a new Inset panel for each selected panel">
         <i class="bi-box-arrow-right"></i>
         Create Inset
     </button>

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -93,9 +93,88 @@
 </form>
 
 <form class="form-inline clearfix" role="form" style="margin-top: 10px;">
-    <button class="create_inset btn btn-sm btn-outline-secondary"
+    <h5>Inset Panel</h5>
+
+    <div class="btn-group">
+        <button type="button" class="label-position btn btn-outline-secondary btn-sm dropdown-toggle" 
+                title="Position" data-bs-toggle="dropdown">
+            <i data-position="right" class="bi-box-arrow-right dropdown_icon"></i>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            <li role="presentation" class="dropdown-header">Inside Corners</li>
+            <!-- NB: dropdown_icon is picked on choosing dropdown, replaces icon in button above -->
+            <li><a class="dropdown-item" href="#">
+                <i data-position="left" class="bi-box-arrow-left dropdown_icon"></i> Left</a>
+            </li>
+            <li><a class="dropdown-item" href="#">
+                <i data-position="top" class="bi-box-arrow-up dropdown_icon"></i> Top</a>
+            </li>
+            <li><a class="dropdown-item" href="#">
+                <i data-position="right" class="bi-box-arrow-right dropdown_icon"></i> Right</a>
+            </li>
+            <li><a class="dropdown-item" href="#">
+                <i data-position="bottom" class="bi-box-arrow-down dropdown_icon"></i> Bottom</a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="btn-group">
+        <button type="button" class="inset-color btn btn-outline-secondary btn-sm dropdown-toggle" title="Label Color"
+            data-bs-toggle="dropdown">
+            <span data-color="FFFFFF" style="background-color:#FFFFFF" class="dropdown_icon">&nbsp &nbsp &nbsp</span>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu colorpicker" role="menu">
+            <!-- NB: dropdown_icon is picked on choosing dropdown, replaces icon in button above -->
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="000000" style="background-color:#000">&nbsp &nbsp &nbsp</span>&nbsp Black
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="0000FF" style="background-color:#00f">&nbsp &nbsp &nbsp</span>&nbsp Blue
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="00FF00" style="background-color:#0f0">&nbsp &nbsp &nbsp</span>&nbsp Green
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="FF0000" style="background-color:#f00">&nbsp &nbsp &nbsp</span>&nbsp Red
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="FFFF00" style="background-color:#ff0">&nbsp &nbsp &nbsp</span>&nbsp Yellow
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="FFFFFF" style="background-color:#fff">&nbsp &nbsp &nbsp</span>&nbsp White
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="FF00FF" style="background-color:#f0f">&nbsp &nbsp &nbsp</span>&nbsp Magenta
+            </a></li>
+            <li><a class="dropdown-item" href="#">
+                <span class="dropdown_icon" data-color="00FFFF" style="background-color:#0ff">&nbsp &nbsp &nbsp</span>&nbsp Cyan
+            </a></li>
+            <li class="dropdown-divider"></li>
+            <li><a class="dropdown-item" data-color="colorpicker" data-oldcolor="FFFFFF" href="#">
+                <span class="dropdown_icon colorpickerOption">&nbsp &nbsp &nbsp</span>&nbsp More Colors...
+            </a></li>
+        </ul>
+    </div>
+
+    <div class="btn-group">
+        <button type="button" class="inset-width btn btn-outline-secondary btn-sm dropdown-toggle" title="Inset line width"
+            data-bs-toggle="dropdown">
+            <span class='dropdown_icon' data-line-width="<%= lineWidth %>"><%= lineWidth %> pt</span>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
+
+            <% _.each([0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30],function(p){ %>
+                <li><a class='dropdown-item' href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
+            <% }); %>
+
+        </ul>
+    </div>
+
+    <button class="create_inset btn btn-sm btn-success float-end"
         title="Create a new Inset panel for each selected panel">
-        <i class="bi-box-arrow-right"></i>
         Create Inset
     </button>
 </form>

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -91,4 +91,13 @@
     </div>
 
 </form>
+
+<form class="form-inline clearfix" role="form" style="margin-top: 10px;">
+    <div class="float-end">
+        <button class="create_inset btn btn-sm btn-success">
+            New Inset Panel
+        </button>
+    </div>
+
+</form>
 <% } %>

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -57,7 +57,7 @@
         <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
 
             <% _.each([0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30],function(p){ %>
-                <li><a class='dropdown-item' href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
+                <li><a class='dropdown-item' href='#'><span class="dropdown_icon" data-line-width='<%= p %>'><%= p %> pt</span></a></li>
             <% }); %>
 
         </ul>
@@ -167,7 +167,7 @@
         <ul class="dropdown-menu dropdownSelect lineWidth" role="menu">
 
             <% _.each([0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30],function(p){ %>
-                <li><a class='dropdown-item' href='#'><span data-line-width='<%= p %>'><%= p %> pt</span></a></li>
+                <li><a class='dropdown-item' href='#'><span class="dropdown_icon" data-line-width='<%= p %>'><%= p %> pt</span></a></li>
             <% }); %>
 
         </ul>

--- a/src/templates/rois_form.template.html
+++ b/src/templates/rois_form.template.html
@@ -93,11 +93,9 @@
 </form>
 
 <form class="form-inline clearfix" role="form" style="margin-top: 10px;">
-    <div class="float-end">
-        <button class="create_inset btn btn-sm btn-success">
-            New Inset Panel
-        </button>
-    </div>
-
+    <button class="create_inset btn btn-sm btn-outline-secondary">
+        <i class="bi-box-arrow-right"></i>
+        Create Inset
+    </button>
 </form>
 <% } %>


### PR DESCRIPTION
Fixes #319 

This replaces the tricky "create Inset" workflow (copy Rectangle and paste as Crop region or vice versa) with a single button click, and the Inset panel and Rectangle should stay in sync when either are updated.

To test:

- Select one or more panels and in the right-tab, under `ROIs`, click the "Create Inset" button
- This will create a new Inset Panel and a corresponding Rectangle:

![Screenshot 2024-04-26 at 11 06 04](https://github.com/ome/omero-figure/assets/900055/97a86dfb-ce4e-4121-95c6-40639e31a0e0)

- When you Pan, Zoom, rotate or Resize the Inset Panel, the Rectangle will update in sync (NB: we previously handled rotation when copying crop region and pasting as ROI by creating a Polygon instead of rotated Rectangle)
- When you edit the Rectangle (via the ROI dialog) the Inset Panel will update accordingly
- If you copy and paste the Inset panel to create e.g. split-view panels, each of these panels is "linked" to the original Rectangle (updating any one of them will update the Rectangle and vice-versa)
- If you copy and paste the parent panel that contains the Rectangle, both Rectangles in these panels are linked to the Inset Panel(s)
- Save the Figure, then re-open (can simply refresh the page) and check that the Rectangle and Inset panels are still kept in sync.
