### PR TITLE
Don't update zoom to undefined on setId

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -103,7 +103,6 @@
                 'pixel_size_x_unit': data.pixel_size_x_unit,
                 'pixel_size_z_unit': data.pixel_size_z_unit,
                 'deltaT': data.deltaT,
-                'zoom':data.zoom,
             };
 
             // theT and theZ are not changed unless we have to...


### PR DESCRIPTION
Fixes a bug introduced in #527: On `Edit ID` the panel zoom is updated to `undefined` since the incoming image data has no zoom info so `data.zoom` is always undefined.

This results in rendering errors - e.g. Zoom slider `0` and other `NaN` values below:

![Screenshot 2024-04-08 at 17 49 39](https://github.com/ome/omero-figure/assets/900055/89c02865-0b18-4eed-a2d1-1d1578c6edb7)

To test:

 - Zoom a panel, then `Edit ID` to replace image with another.
 - The zoom should remain unchanged and after de-selecting and re-selecting the panel (to trigger update of right panels) the zoom controls, viewport x, y, width, height etc should be rendered correctly.

cc @Rdornier 