### PR TITLE
Figure_To_Pdf: use max plane size to select the appropriate zoom level

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1542,10 +1542,10 @@ class FigureExport(object):
 
         # start big, and go until we reach target size
         zm = 0
+        max_plane = max_sizes[0] * max_sizes[1]
         while (zm < max_level and
                zm_levels[zm] * width > max_width or
-               zm_levels[zm] * width > max_sizes[0] or
-               zm_levels[zm] * height > max_sizes[1]):
+               zm_levels[zm] * width * zm_levels[zm] * height > max_plane):
             zm = zm + 1
 
         level = max_level - zm

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1537,15 +1537,15 @@ class FigureExport(object):
         # e.g. {0: 1.0, 1: 0.25, 2: 0.0625, 3: 0.03123, 4: 0.01440}
         # Pick zoom such that returned image is below MAX size
         max_level = len(zm_levels.keys()) - 1
-
-        # Maximum size that the rendering engine will render without OOM
-        max_plane = self.conn.getDownloadAsMaxSizeSetting()
+        # Maximum size that the rendering engine will render
+        max_sizes = self.conn.getMaxPlaneSize()
 
         # start big, and go until we reach target size
         zm = 0
         while (zm < max_level and
                zm_levels[zm] * width > max_width or
-               zm_levels[zm] * width * zm_levels[zm] * height > max_plane):
+               zm_levels[zm] * width > max_sizes[0] or
+               zm_levels[zm] * height > max_sizes[1]):
             zm = zm + 1
 
         level = max_level - zm


### PR DESCRIPTION
The logic selecting the best resolution for the export can select a plane as large as omero.client.download_as.max_size. With a default value of  144000000, this means regions as wide as 12k x 12k can be requested to the server.

This commit proposes to use the max plane width and height instead to select the appropriate resolution level. Both configurations default to 3k and are already used for identifying an image as "big" and navigating through the resolution levels.

This PR should be tested by running the figure export workflow on a large pyramidal images. Adjust the zoom so that the width & height is in the 3k-10k range and run the figure export script.
The server logs should include the arguments passed to the `rednderCompressed` API e.g.

```
2024-04-19 11:34:23,564 INFO  [        ome.services.util.ServiceHandler] (rver-19469)  Meth:	interface omeis.providers.re.RenderingEngine.renderCompressed
2024-04-19 11:34:23,564 INFO  [        ome.services.util.ServiceHandler] (rver-19469)  Args:	[Type: XY, z=0, t=0; Region: x=19428 y=13901 width=7142 height=5110, renderShapes=false, shapeIds=[]]
2024-04-19 11:34:23,564 INFO  [             omeis.providers.re.Renderer] (rver-19469) Using: 'omeis.providers.re.HSBStrategy' rendering strategy.
```

With this change included, using the same OMERO.figure configuration, the export script should select a smaller resolution level with `width` and `height` both being smaller than 3k by default e.g.

```
2024-04-19 11:34:59,931 INFO  [        ome.services.util.ServiceHandler] (rver-19467)  Meth:	interface omeis.providers.re.RenderingEngine.renderCompressed
2024-04-19 11:34:59,931 INFO  [        ome.services.util.ServiceHandler] (rver-19467)  Args:	[Type: XY, z=0, t=0; Region: x=4857 y=3475 width=1785 height=1277, renderShapes=false, shapeIds=[]]
2024-04-19 11:34:59,931 INFO  [             omeis.providers.re.Renderer] (rver-19467) Using: 'omeis.providers.re.HSBStrategy' rendering strategy.
```

As a side-effect, this significantly reduces the size of the exported PDF