### PR TITLE
Max projection bytes

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -26,7 +26,7 @@ from datetime import datetime
 import os
 from os import path
 import zipfile
-from math import atan2, atan, sin, cos, sqrt, radians, floor, ceil
+from math import atan2, atan, sin, cos, sqrt, radians, floor, ceil, log2
 from copy import deepcopy
 import re
 
@@ -1681,8 +1681,23 @@ class FigureExport(object):
 
         if 'z_projection' in panel and panel['z_projection']:
             if 'z_start' in panel and 'z_end' in panel:
-                image.setProjection('intmax')
-                image.setProjectionRange(panel['z_start'], panel['z_end'])
+                # check max_projection_bytes
+                pixel_range = image.getPixelRange()
+                bytes_per_pixel = ceil(log2(pixel_range[1]) / 8.0)
+                channels = sum([1 if ch.isActive() else 0 for ch in image.getChannels()])
+                z_range = panel['z_end'] - panel['z_start']
+                proj_bytes = z_range * image.getSizeX() * image.getSizeY() * channels * bytes_per_pixel
+
+                cfg = self.conn.getConfigService()
+                max_bytes = int(cfg.getConfigValue('omero.pixeldata.max_projection_bytes'))
+
+                if proj_bytes <= max_bytes:
+                    image.setProjection('intmax')
+                    image.setProjectionRange(panel['z_start'], panel['z_end'])
+                else:
+                    print(f'projected_bytes {proj_bytes} exceeds MAX_PROJECTED_BYTES limit: {max_bytes}')
+                    # Turn off all channels to render a black panel
+                    image.setActiveChannels([])
 
         # If big image, we don't want to render the whole plane
         if self.is_big_image(image):

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1679,6 +1679,7 @@ class FigureExport(object):
         size_x = image.getSizeX()
         size_y = image.getSizeY()
         size_z = image.getSizeZ()
+        size_c = image.getSizeC()
 
         if 'z_projection' in panel and panel['z_projection']:
             if 'z_start' in panel and 'z_end' in panel:
@@ -1687,7 +1688,7 @@ class FigureExport(object):
                 bytes_per_pixel = ceil(log2(pixel_range[1]) / 8.0)
                 act_chs = [ch for ch in image.getChannels() if ch.isActive()]
                 proj_bytes = (size_z * size_x * size_y
-                              * len(act_chs) * bytes_per_pixel)
+                              * size_c * bytes_per_pixel)
 
                 cfg = self.conn.getConfigService()
                 max_bytes = int(cfg.getConfigValue(

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1686,7 +1686,6 @@ class FigureExport(object):
                 # check max_projection_bytes
                 pixel_range = image.getPixelRange()
                 bytes_per_pixel = ceil(log2(pixel_range[1]) / 8.0)
-                act_chs = [ch for ch in image.getChannels() if ch.isActive()]
                 proj_bytes = (size_z * size_x * size_y
                               * size_c * bytes_per_pixel)
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1678,6 +1678,7 @@ class FigureExport(object):
         t = panel['theT']
         size_x = image.getSizeX()
         size_y = image.getSizeY()
+        size_z = image.getSizeZ()
 
         if 'z_projection' in panel and panel['z_projection']:
             if 'z_start' in panel and 'z_end' in panel:
@@ -1685,8 +1686,7 @@ class FigureExport(object):
                 pixel_range = image.getPixelRange()
                 bytes_per_pixel = ceil(log2(pixel_range[1]) / 8.0)
                 act_chs = [ch for ch in image.getChannels() if ch.isActive()]
-                z_range = panel['z_end'] - panel['z_start']
-                proj_bytes = (z_range * image.getSizeX() * image.getSizeY()
+                proj_bytes = (size_z * size_x * size_y
                               * len(act_chs) * bytes_per_pixel)
 
                 cfg = self.conn.getConfigService()

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1684,18 +1684,21 @@ class FigureExport(object):
                 # check max_projection_bytes
                 pixel_range = image.getPixelRange()
                 bytes_per_pixel = ceil(log2(pixel_range[1]) / 8.0)
-                channels = sum([1 if ch.isActive() else 0 for ch in image.getChannels()])
+                act_chs = [ch for ch in image.getChannels() if ch.isActive()]
                 z_range = panel['z_end'] - panel['z_start']
-                proj_bytes = z_range * image.getSizeX() * image.getSizeY() * channels * bytes_per_pixel
+                proj_bytes = (z_range * image.getSizeX() * image.getSizeY()
+                              * len(act_chs) * bytes_per_pixel)
 
                 cfg = self.conn.getConfigService()
-                max_bytes = int(cfg.getConfigValue('omero.pixeldata.max_projection_bytes'))
+                max_bytes = int(cfg.getConfigValue(
+                    'omero.pixeldata.max_projection_bytes'))
 
                 if proj_bytes <= max_bytes:
                     image.setProjection('intmax')
                     image.setProjectionRange(panel['z_start'], panel['z_end'])
                 else:
-                    print(f'projected_bytes {proj_bytes} exceeds MAX_PROJECTED_BYTES limit: {max_bytes}')
+                    print(f'projected_bytes {proj_bytes} exceeds '
+                          f'MAX_PROJECTED_BYTES limit: {max_bytes}')
                     # Turn off all channels to render a black panel
                     image.setActiveChannels([])
 

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -33,6 +33,11 @@ urlpatterns = [
     re_path(r'^imgData/(?P<image_id>[0-9]+)/$', views.img_data_json,
             name='figure_imgData'),
 
+    re_path(r'^max_projection_range_exceeded/'
+            r'(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
+            views.max_projection_range_exceeded,
+            name='max_projection_range_exceeded'),
+
     # Send json to OMERO to create pdf using scripting service
     re_path(r'^make_web_figure/', views.make_web_figure,
             name='make_web_figure'),

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -33,10 +33,10 @@ urlpatterns = [
     path('imgData/<int:image_id>/', views.img_data_json,
          name='figure_imgData'),
 
-    re_path(r'^max_projection_range_exceeded/'
-            r'(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
-            views.max_projection_range_exceeded,
-            name='max_projection_range_exceeded'),
+    path(r'^max_projection_range_exceeded/'
+         r'(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
+         views.max_projection_range_exceeded,
+         name='max_projection_range_exceeded'),
 
     # Send json to OMERO to create pdf using scripting service
     path('make_web_figure/', views.make_web_figure,
@@ -80,7 +80,7 @@ urlpatterns = [
     path('timestamps/', views.timestamps, name='figure_timestamps'),
 
     # Get pixelsType for images. Use query ?image=1&image=2
-    re_path(r'^pixels_type/$', views.pixels_type, name='figure_pixels_type'),
+    path('pixels_type/', views.pixels_type, name='figure_pixels_type'),
 
     # Get Z scale for images
     # Use query ?image=1&image=2

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -76,6 +76,9 @@ urlpatterns = [
     # Use query ?image=1&image=2
     re_path(r'^timestamps/$', views.timestamps, name='figure_timestamps'),
 
+    # Get pixelsType for images. Use query ?image=1&image=2
+    re_path(r'^pixels_type/$', views.pixels_type, name='figure_pixels_type'),
+
     # Get Z scale for images
     # Use query ?image=1&image=2
     re_path(r'^z_scale/$', views.z_scale, name='figure_z_scale'),

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -18,7 +18,7 @@
 
 from omeroweb.webgateway import views as webgateway_views
 from . import views
-from django.urls import path
+from django.urls import path, re_path
 
 
 urlpatterns = [
@@ -33,10 +33,10 @@ urlpatterns = [
     path('imgData/<int:image_id>/', views.img_data_json,
          name='figure_imgData'),
 
-    path(r'^max_projection_range_exceeded/'
-         r'(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
-         views.max_projection_range_exceeded,
-         name='max_projection_range_exceeded'),
+    re_path(r'^max_projection_range_exceeded/'
+            r'(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
+            views.max_projection_range_exceeded,
+            name='max_projection_range_exceeded'),
 
     # Send json to OMERO to create pdf using scripting service
     path('make_web_figure/', views.make_web_figure,

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -155,7 +155,7 @@ def max_projection_range_exceeded(request, iid, z=None, t=None,
     from PIL import Image, ImageDraw, ImageFont
 
     font20 = ImageFont.load_default(20)
-    msg = "Max Z projection exceeded"
+    msg = "Max Z projection disabled"
     msg_size = font20.getbbox(msg)
     txt_w = msg_size[2]
     txt_h = msg_size[3]

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -154,7 +154,6 @@ def max_projection_range_exceeded(request, iid, z=None, t=None,
 
     from PIL import Image, ImageDraw, ImageFont
 
-    font14 = ImageFont.load_default(14)
     font20 = ImageFont.load_default(20)
     msg = "Max Z projection exceeded"
     msg_size = font20.getbbox(msg)

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -160,25 +160,15 @@ def max_projection_range_exceeded(request, iid, z=None, t=None,
     msg_size = font20.getbbox(msg)
     txt_w = msg_size[2]
     txt_h = msg_size[3]
-    advice = "Try to turn off channels or reduce Z-range"
-    advice_size = font14.getbbox(advice)
-    adv_w = advice_size[2]
-    adv_h = advice_size[3]
 
-    image_size = max(txt_w, adv_w) + 10
-    line_space = 10
-    total_h = txt_h + adv_h + line_space
+    image_size = txt_w + 10
 
     im = Image.new("RGB", (image_size, image_size), (5, 0, 0))
     draw = ImageDraw.Draw(im)
-    text_y = im.size[1]/2 - total_h/2
+    text_y = im.size[1]/2 - txt_h/2
     draw.text((im.size[0]/2 - txt_w/2, text_y), msg,
               font=font20,
               fill=(256, 256, 256))
-    text_y += txt_h + line_space
-    draw.text((im.size[0]/2 - adv_w/2, text_y), advice,
-              font=font14,
-              fill=(200, 200, 200))
 
     rv = BytesIO()
     im.save(rv, "jpeg", quality=90)

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -192,6 +192,26 @@ def timestamps(request, conn=None, **kwargs):
 
 
 @login_required()
+def pixels_type(request, conn=None, **kwargs):
+
+    iids = request.GET.getlist('image')
+    data = {}
+    for iid in iids:
+        try:
+            iid = int(iid)
+        except ValueError:
+            pass
+        else:
+            image = conn.getObject('Image', iid)
+            if image is not None:
+                data[image.id] = {
+                    "pixelsType": image.getPixelsType(),
+                    "pixel_range": image.getPixelRange()
+                }
+    return JsonResponse(data)
+
+
+@login_required()
 def z_scale(request, conn=None, **kwargs):
 
     iids = request.GET.getlist('image')

--- a/src/css/figure.css
+++ b/src/css/figure.css
@@ -646,11 +646,6 @@
     .z-projection {
         padding: 1px 5px 5px;
     }
-    .z-projection span{
-        background-image: url("../images/projection20.png");
-        width: 20px;
-        height: 20px;
-    }
     .crop-btn span{
         background-image: url("../images/crop20.png");
         width: 20px;

--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,7 @@
       const IS_PUBLIC_USER = false;
       // Images larger than this are 'big' tiled images
       const MAX_PLANE_SIZE = 10188864;
+      const MAX_PROJECTION_BYTES = 1024 * 1024 * 256;
 
       const LOCAL_STORAGE_RECOVERED_FIGURE = "recoveredFigure" + USER_ID;
 

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -12,7 +12,7 @@
 
     // Version of the json file we're saving.
     // This only needs to increment when we make breaking changes (not linked to release versions.)
-    var VERSION = 7;
+    var VERSION = 8;
 
 
     // ------------------------- Figure Model -----------------------------------
@@ -280,6 +280,31 @@
                     }
                 });
             }
+
+            if (v < 8) {
+                console.log("Transforming to VERSION 8");
+                // need to load pixelsType.
+                var iids = json.panels.map(p => p.imageId);
+                console.log('Load pixelsType for images', iids);
+                if (iids.length > 0) {
+                    var ptUrl = BASE_WEBFIGURE_URL + 'pixels_type/';
+                    ptUrl += '?image=' + iids.join('&image=');
+                    getJson(ptUrl).then(data => {
+                        // Update all panels
+                        // NB: By the time that this callback runs, the panels will have been created
+                        self.panels.forEach(function(p){
+                            var iid = p.get('imageId');
+                            if (data[iid]) {
+                                p.set({
+                                    'pixelsType': data[iid].pixelsType,
+                                    'pixel_range': data[iid].pixel_range
+                                });
+                            }
+                        });
+                    });
+                }
+            }
+
             return json;
         },
 
@@ -573,6 +598,8 @@
                         'pixel_size_x_unit': data.pixel_size.unitX,
                         'pixel_size_z_unit': data.pixel_size.unitZ,
                         'deltaT': data.deltaT,
+                        'pixelsType': data.meta.pixelsType,
+                        'pixels_range': data.pixels_range,
                     };
                     if (baseUrl) {
                         n.baseUrl = baseUrl;

--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -599,7 +599,7 @@
                         'pixel_size_z_unit': data.pixel_size.unitZ,
                         'deltaT': data.deltaT,
                         'pixelsType': data.meta.pixelsType,
-                        'pixels_range': data.pixels_range,
+                        'pixel_range': data.pixel_range,
                     };
                     if (baseUrl) {
                         n.baseUrl = baseUrl;

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -560,15 +560,15 @@
             }
         },
 
-        // Does sizeXYZ, pixelType and active Channels exceed MAX_PROJECTION_BYTES?
+        // Does sizeXYZ, pixelType and Channels exceed MAX_PROJECTION_BYTES?
         isMaxProjectionBytesExceeded: function() {
             let bytes_per_pixel = 4;
             if (this.get("pixel_range")) {
                 bytes_per_pixel = Math.ceil(Math.log2(this.get("pixel_range")[1]) / 8.0);
             }
-            let active_channels = this.get("channels").reduce((prev, channel) => channel.active ? prev + 1 : prev, 0);
+            let sizeC = this.get("channels").length;
             let sizeXYZ = this.get('orig_width') * this.get('orig_height') * this.get('sizeZ');
-            let total_bytes = bytes_per_pixel * active_channels * sizeXYZ;
+            let total_bytes = bytes_per_pixel * sizeC * sizeXYZ;
             return total_bytes > MAX_PROJECTION_BYTES;
         },
 

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -93,6 +93,8 @@
             // we replace these attributes...
             var newData = {'imageId': data.imageId,
                 'name': data.name,
+                'pixelsType': data.pixelsType,
+                'pixel_range': data.pixel_range,
                 'sizeZ': data.sizeZ,
                 'sizeT': data.sizeT,
                 'orig_width': data.orig_width,
@@ -556,6 +558,21 @@
                     this.set('z_projection', false);
                 }
             }
+        },
+
+        getMaxZprojPlanes: function() {
+            const MAX_BYTES = 1024 * 1024 * 256;
+            let bytes_per_pixel = 4;
+            if (this.get("pixel_range")) {
+                bytes_per_pixel = Math.ceil(Math.log2(this.get("pixel_range")[1]) / 8.0);
+            }
+            console.log('pixel_range', this.get("pixel_range"), 'bytes_per_pixel', bytes_per_pixel);
+            let active_channels = this.get("channels").reduce((prev, channel) => channel.active ? prev + 1 : prev, 0);
+            console.log('active_channels', active_channels);
+            let max_planes = MAX_BYTES / bytes_per_pixel / (this.get('orig_width') * this.get('orig_height'));
+            max_planes = Math.floor(max_planes / active_channels);
+            console.log("max_planes", max_planes);
+            return max_planes;
         },
 
         // When a multi-select rectangle is drawn around several Panels

--- a/src/js/views/info_panel_view.js
+++ b/src/js/views/info_panel_view.js
@@ -244,7 +244,8 @@ var InfoPanelView = Backbone.View.extend({
             } else {
                 json.name = title;
                 // compare json summary so far with this Panel
-                var attrs = ["imageId", "orig_width", "orig_height", "sizeT", "sizeZ", "x", "y", "width", "height", "dpi", "min_export_dpi", "max_export_dpi"];
+                var attrs = ["imageId", "orig_width", "orig_height", "sizeT", "sizeZ", "x", "y",
+                             "width", "height", "dpi", "min_export_dpi", "max_export_dpi", "pixelsType"];
                 _.each(attrs, function(a){
                     if (json[a] != this_json[a]) {
                         if (a === 'x' || a === 'y' || a === 'width' || a === 'height') {

--- a/src/js/views/modal_views.js
+++ b/src/js/views/modal_views.js
@@ -298,6 +298,8 @@ import { hideModal } from "./util";
                 var newImg = {
                     'imageId': data.id,
                     'name': data.meta.imageName,
+                    'pixelsType': data.meta.pixelsType,
+                    'pixel_range': data.pixel_range,
                     // 'width': data.size.width,
                     // 'height': data.size.height,
                     'sizeZ': data.size.z,

--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -34,7 +34,7 @@
                 this.render_layout);
             this.listenTo(this.model, 'change:scalebar change:pixel_size_x', this.render_scalebar);
             this.listenTo(this.model,
-                'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi',
+                'change:zoom change:dx change:dy change:width change:height change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:min_export_dpi change:pixel_range',
                 this.render_image);
             this.listenTo(this.model,
                 'change:channels change:zoom change:dx change:dy change:width change:height change:rotation change:labels change:theT change:deltaT change:theZ change:deltaZ change:z_projection change:z_start change:z_end',

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1091,9 +1091,11 @@
                 sum_sizeZ = 0,
                 rotation,
                 z_projection,
+                max_z_proj_planes = Infinity,
                 zp;
             if (this.models) {
                 this.models.forEach(function(m, i){
+                    max_z_proj_planes = Math.min(max_z_proj_planes, m.getMaxZprojPlanes());
                     rotation = m.get('rotation');
                     max_rotation = Math.max(max_rotation, rotation);
                     sum_rotation += rotation;
@@ -1123,6 +1125,7 @@
                 const z_projection_disabled = ((sum_sizeZ === this.models.length) || anyBig);
 
                 html = this.template({
+                    zrange_max: max_z_proj_planes,
                     projectionIconUrl,
                     'z_projection_disabled': z_projection_disabled,
                     'rotation': rotation,

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1091,11 +1091,11 @@
                 sum_sizeZ = 0,
                 rotation,
                 z_projection,
-                max_z_proj_planes = Infinity,
+                projection_bytes_exceeded = [],
                 zp;
             if (this.models) {
                 this.models.forEach(function(m, i){
-                    max_z_proj_planes = Math.min(max_z_proj_planes, m.getMaxZprojPlanes());
+                    projection_bytes_exceeded.push(m.isMaxProjectionBytesExceeded())
                     rotation = m.get('rotation');
                     max_rotation = Math.max(max_rotation, rotation);
                     sum_rotation += rotation;
@@ -1110,6 +1110,7 @@
                         }
                     }
                 });
+                let proj_bytes_exceeded = projection_bytes_exceeded.some(b => b);
                 var avg_rotation = sum_rotation / this.models.length;
                 if (avg_rotation === max_rotation) {
                     rotation = avg_rotation;
@@ -1124,13 +1125,9 @@
                 // Don't currently support Z_projection on Big images.
                 const z_projection_disabled = ((sum_sizeZ === this.models.length) || anyBig);
 
-                let sizeZ = this.models.getIfEqual('sizeZ');
-                let show_max_Zrange = sizeZ && z_projection && max_z_proj_planes < sizeZ;
-
                 html = this.template({
                     max_projection_bytes: MAX_PROJECTION_BYTES,
-                    zrange_max: max_z_proj_planes,
-                    show_max_Zrange: show_max_Zrange,
+                    proj_bytes_exceeded: proj_bytes_exceeded,
                     projectionIconUrl,
                     'z_projection_disabled': z_projection_disabled,
                     'rotation': rotation,

--- a/src/js/views/right_panel_view.js
+++ b/src/js/views/right_panel_view.js
@@ -1124,8 +1124,13 @@
                 // Don't currently support Z_projection on Big images.
                 const z_projection_disabled = ((sum_sizeZ === this.models.length) || anyBig);
 
+                let sizeZ = this.models.getIfEqual('sizeZ');
+                let show_max_Zrange = sizeZ && z_projection && max_z_proj_planes < sizeZ;
+
                 html = this.template({
+                    max_projection_bytes: MAX_PROJECTION_BYTES,
                     zrange_max: max_z_proj_planes,
+                    show_max_Zrange: show_max_Zrange,
                     projectionIconUrl,
                     'z_projection_disabled': z_projection_disabled,
                     'rotation': rotation,

--- a/src/js/views/scalebar_form_view.js
+++ b/src/js/views/scalebar_form_view.js
@@ -156,8 +156,9 @@ var ScalebarFormView = Backbone.View.extend({
             } else {
                 let pix_sze = m.get('pixel_size_x');
                 // account for floating point imprecision when comparing
+                pix_sze = pix_sze ? pix_sze.toFixed(10) : pix_sze;
                 if (json.pixel_size_x != '-' &&
-                    json.pixel_size_x.toFixed(10) != pix_sze.toFixed(10)) {
+                    json.pixel_size_x.toFixed(10) != pix_sze) {
                         json.pixel_size_x = '-';
                 }
                 if (json.pixel_size_symbol != m.get('pixel_size_x_symbol')) {

--- a/src/templates/image_display_options.template.html
+++ b/src/templates/image_display_options.template.html
@@ -16,12 +16,15 @@
                 <% if(z_projection) { %>zp-btn-down<% } else if (typeof z_projection == 'boolean') { %><% } else { %>ch-btn-flat<% }%>"
                 <% if (z_projection_disabled) { %>disabled="disabled"<% } %>
                 >
-            <img src="<%= projectionIconUrl %>" />
-        </button>
-    </div>
 
-    <div style="font-size: 80%; line-height: 1.3;">
-        <button class="btn btn-sm btn-link" style="padding: 0; margin: 0; font-size: 0.8rem; text-align: left;;">
-            Z-range max: <%= zrange_max %>
+                <% if(show_max_Zrange) { %>
+                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+                    title="Max Z-projection range with current channels active. MAX_PROJECTION_BYTES = <%= max_projection_bytes %>">
+                    Max <%= zrange_max %>
+                    <span class="visually-hidden">Maximum Z-projection range</span>
+                </span>
+                <% } %>
+
+            <img src="<%= projectionIconUrl %>" />
         </button>
     </div>

--- a/src/templates/image_display_options.template.html
+++ b/src/templates/image_display_options.template.html
@@ -19,3 +19,9 @@
             <img src="<%= projectionIconUrl %>" />
         </button>
     </div>
+
+    <div style="font-size: 80%; line-height: 1.3;">
+        <button class="btn btn-sm btn-link" style="padding: 0; margin: 0; font-size: 0.8rem; text-align: left;;">
+            Z-range max: <%= zrange_max %>
+        </button>
+    </div>

--- a/src/templates/image_display_options.template.html
+++ b/src/templates/image_display_options.template.html
@@ -11,19 +11,12 @@
 
 
     <div class="btn-group image-display-options"
-         title="Maximum intensity Z-projection (choose range with 2 handles on Z-slider)">
+         title="Maximum intensity Z-projection <% if (proj_bytes_exceeded) { print('exceeds MAX_PROJECTION_BYTES: ' + max_projection_bytes ) }
+         else { %>(choose range with 2 handles on Z-slider)<% } %>">
         <button type="button" class="btn btn-outline-secondary btn-sm z-projection
                 <% if(z_projection) { %>zp-btn-down<% } else if (typeof z_projection == 'boolean') { %><% } else { %>ch-btn-flat<% }%>"
                 <% if (z_projection_disabled) { %>disabled="disabled"<% } %>
                 >
-
-                <% if(show_max_Zrange) { %>
-                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                    title="Max Z-projection range with current channels active. MAX_PROJECTION_BYTES = <%= max_projection_bytes %>">
-                    Max <%= zrange_max %>
-                    <span class="visually-hidden">Maximum Z-projection range</span>
-                </span>
-                <% } %>
 
             <img src="<%= projectionIconUrl %>" />
         </button>

--- a/src/templates/image_display_options.template.html
+++ b/src/templates/image_display_options.template.html
@@ -15,7 +15,7 @@
          else { %>(choose range with 2 handles on Z-slider)<% } %>">
         <button type="button" class="btn btn-outline-secondary btn-sm z-projection
                 <% if(z_projection) { %>zp-btn-down<% } else if (typeof z_projection == 'boolean') { %><% } else { %>ch-btn-flat<% }%>"
-                <% if (z_projection_disabled) { %>disabled="disabled"<% } %>
+                <% if ((!z_projection && proj_bytes_exceeded) || z_projection_disabled) { %>disabled="disabled"<% } %>
                 >
 
             <img src="<%= projectionIconUrl %>" />

--- a/src/templates/info_panel.template.html
+++ b/src/templates/info_panel.template.html
@@ -40,6 +40,8 @@
                         print(_.escape(c)); print((i < channels.length-1) ? ", " : "");
                     }); %>
                 </small></div>
+                <div class="col-sm-5"><small><strong>Pixels Type</strong>:</small></div>
+                <div class="col-sm-7"><small><%= pixelsType %></small></div>
             </td></tr>
         </tbody>
     </table>


### PR DESCRIPTION
Fixes #440.

This protects users from requesting Z-projections exceeding the `MAX_PROJECTION_BYTES` limit of `1024 * 1024 * 256` bytes or a value configured on the server `omero.pixeldata.max_projection_bytes`.
We always take into account the number of *active* channels rather than total channel count.

When a user enables Z-projection on an image, we test whether the full Z-range projection (with current channels enabled) exceeds the `MAX_PROJECTION_BYTES`. If so, the maximum number of Z-planes that can be projected is shown in red (tooltip includes the MAX_PROJECTION_BYTES limit). This limit will change when channels are turned on/off.

If a user exceeds the Z-projection limit using the Z-range sliders, we show a warning message instead of the Z-projected image. 

![Screenshot 2024-05-02 at 16 55 31](https://github.com/ome/omero-figure/assets/900055/66241b15-de3b-40cf-9e21-cd16ac30e986)

To test: (I have already created https://merge-ci.openmicroscopy.org/web/figure/file/3901 as follows):

- *BEFORE* this PR is merged, find/create one or more images that are bigger than `1024 * 1024 * 256` bytes. Might be easiest to create fake images. E.g. I tested with `testProjection&sizeX=1952&sizeY=1952&sizeZ=73&sizeC=4&pixelType=int16.fake` based on https://forum.image.sc/t/z-projections-disabled/95042 and `testProjection&sizeX=1024&sizeY=1024&sizeZ=50&sizeC=4&pixelType=int8.fake` which falls under the limit when a single channel is enabled.
- Save a Figure that includes these images with Z-projection exceeding the limit.
 

 - *WITH* this PR: Open your existing OMERO.figure and check in the Info panel that correct pixelsType is shown (this data isn't included in existing figures but is loaded on the fly when you open an older figure).
 - Add these to a figure - they should also show the correct pixelsType in Info panel.
 - Enable Z-projection for large and small images. Only those that can exceed the max projected bytes (with the current channels enabled) will show the red `Max N` with a tooltip to show the meaning.
 - Drag the Z-range sliders - when you choose a range that exceeds the limit in red, you should see the placeholder warning shown instead of requesting the server to project the image:
