### PR TITLE
Bugfixes may2024

### DIFF
--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -219,8 +219,8 @@ var ChannelSliderView = Backbone.View.extend({
         let $target = $(event.target);
         let value = parseFloat(event.target.value);
         let max = $target.attr('max');
+        let min = $target.attr('min');
         let chIndex = $target.data('idx');
-        value = (max > SLIDER_INCR_CUTOFF) ? value : value.toFixed(2);
         // ensure that start < end
         const start = $target.hasClass("ch_start_slider");
         if (start) {
@@ -236,7 +236,8 @@ var ChannelSliderView = Backbone.View.extend({
                 return;
             }
         }
-        // simply update the correct text input...
+        // simply format and update the correct text input...
+        value = (max - min > SLIDER_INCR_CUTOFF) ? value : value.toFixed(2);
         if (start){
             $(`.channel_slider_${chIndex} .ch_start input`).val(value);
         } else {

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -344,7 +344,7 @@ var ChannelSliderView = Backbone.View.extend({
                 var endsNotEqual = ends.reduce(allEqualFn, ends[0]) === undefined;
                 var min = mins.reduce(reduceFn(Math.min));
                 var max = maxs.reduce(reduceFn(Math.max));
-                if (max > SLIDER_INCR_CUTOFF) {
+                if (max - min > SLIDER_INCR_CUTOFF) {
                     // If we have a large range, use integers, otherwise format to 2dp
                     startAvg = parseInt(startAvg);
                     endAvg = parseInt(endAvg);
@@ -379,7 +379,7 @@ var ChannelSliderView = Backbone.View.extend({
                                                 'endsNotEqual': endsNotEqual,
                                                 'min': min,
                                                 'max': max,
-                                                'step': (max > SLIDER_INCR_CUTOFF) ? 1 : 0.01,
+                                                'step': (max - min > SLIDER_INCR_CUTOFF) ? 1 : 0.01,
                                                 'active': active,
                                                 'lutBgPos': lutBgPos,
                                                 'reverse': reverse,


### PR DESCRIPTION
Fixes for any bugs introduced with the vite.js upgrade:

 - 1) Channel sliders: for small ranges (e.g. float data where brightest pixel is less than 100) we use a smaller step for the slider and we format the value to float when displaying in the start/end text boxes. We also have logic to prevent the 'end' slider value going less than the 'start' slider. In this bug, I wasn't using the full pixel range to check for using small step and float formatting - therefore the test image (see fake image below) with pixel range of `-32768.00` - `72` was using the float formatting etc. Also, the formatting to string step was happening before we compared `start < end` values, so we were comparing string with number which gave a wrong result (so that when sliding the 'end' value, it would get reset to the same as the start value.

`testProjection&sizeX=1952&sizeY=1952&sizeZ=73&sizeC=4&pixelType=int16.fake` 