### PR TITLE
added info on figure scripts upload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,9 @@ The command will display the absolute path to the directory where the applicatio
 *Option 2*: Alternatively, before starting the OMERO.server, copy the script from the figure install
 ``/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py`` to the OMERO.server ``path/to/OMERO.server/lib/scripts/omero/figure_scripts``. Then restart the OMERO.server.
 
+*Option 3*: Upload the script through the OMERO web interface: For this, log into your OMERO web interface as admin, select the scripts icon and click on the "Upload Script" button.
+Select the ``Figure_To_Pdf.py`` script from the directory where you copied it to locally and upload it into the directory ``omero/figure_scripts``.
+
 Now install the script's dependencies:
 
 
@@ -99,10 +102,6 @@ Now install the script's dependencies:
 ::
 
     $ pip install "reportlab<3.6"
-
-*Option 3*: You can also install the dependencies as described in *Option 2* above. Then, upload the script through the OMERO web interface. For this, log into your OMERO web interface
-as admin, select the scripts icon and click on the "Upload Script" button. Select the ``Figure_To_Pdf.py`` script from the directory where you copied it to locally and upload it into the
-directory ``omero/figure_scripts``.
 
 * Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
 

--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,9 @@ Now install the script's dependencies:
 
     $ pip install "reportlab<3.6"
 
-*Option 3*: You can also install the dependencies as described in *Option 2* above. Then, upload the script through the Omero web interface. For this, log into your Omero web interface
-as admin, select the scripts icon and click on the "Upload Script" button. Select the ``Figure_To_Pdf.py`` script from the directory where you copied it to locally and upload.
+*Option 3*: You can also install the dependencies as described in *Option 2* above. Then, upload the script through the OMERO web interface. For this, log into your OMERO web interface
+as admin, select the scripts icon and click on the "Upload Script" button. Select the ``Figure_To_Pdf.py`` script from the directory where you copied it to locally and upload it into the
+directory ``omero/figure_scripts``.
 
 * Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
 

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ Now install the script's dependencies:
 
     $ pip install "reportlab<3.6"
 
+*Option 3*: You can also install the dependencies as described in *Option 2* above. Then, upload the script through the Omero web interface. For this, log into your Omero web interface
+as admin, select the scripts icon and click on the "Upload Script" button. Select the ``Figure_To_Pdf.py`` script from the directory where you copied it to locally and upload.
+
 * Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
 
 ::


### PR DESCRIPTION
Fixes #565 

Just a minor addition to the docs that omero.figure export can also be enabled by simply uploading the script through the web interface.

Best, Johannes