### PR TITLE
Remove numpy from tests_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,5 @@ setup(name="omero-figure",
         'sdist': require_npm(sdist, True),
         'develop': require_npm(develop),
       },
-      tests_require=['pytest', 'numpy'],
+      tests_require=['pytest'],
       )


### PR DESCRIPTION
This removes the listing of `numpy` in test dependencies, which shouldn't be needed as `numpy` is already a dependency of `omero-py`. Seb noticed that we list `numpy` as a dependency as part of his work at https://github.com/ome/omero-py/pull/414.

It was added in https://github.com/ome/omero-figure/pull/356 due to `E       ModuleNotFoundError: No module named 'numpy'` but not sure why/where that was seen...