### PR TITLE
Remove the maximum reportlab version from the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Now install the script's dependencies:
 
 ::
 
-    $ pip install "reportlab<3.6"
+    $ pip install reportlab
 
 * Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
 


### PR DESCRIPTION
Fixes #571 

This capping has already been relaxed from the CI installation instructions in 065989a42b9cc9892684735f2346a4b085a7ad31. For Python 3.12 and above in particular, more recent versions of reportlab are required.