### PR TITLE
usePolling config for Vite auto refresh

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,10 @@ export default {
   },
   server: {
     port: 8080,
-    hot: true
+    hot: true,
+    watch: {
+        usePolling: true
+    }
   },
   build: {
     sourcemap: true,


### PR DESCRIPTION
At least in my case, starting the app with `npm run start` did not refresh the page after modifications.

I found this fix for Vite 3.0.0 and higher (I have v3.2.10)

https://www.reddit.com/r/sveltejs/comments/vzdsc0/npm_run_dev_not_automatically_refreshing_with/


