### PR TITLE
Add Hilo Checkbox for LUT Toggling in Channel Slider View

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -27,9 +27,6 @@
             pixel_size_x_unit: 'MICROMETER',
             rotation_symbol: '\xB0',
             max_export_dpi: 1000,
-            hilo_enabled: false,
-            hilo_original_colors: [],
-
             // 'export_dpi' optional value to resample panel on export
             // model includes 'scalebar' object, e.g:
             // scalebar: {length: 10, position: 'bottomleft', color: 'FFFFFF',

--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -27,6 +27,8 @@
             pixel_size_x_unit: 'MICROMETER',
             rotation_symbol: '\xB0',
             max_export_dpi: 1000,
+            hilo_enabled: false,
+            hilo_original_colors: [],
 
             // 'export_dpi' optional value to resample panel on export
             // model includes 'scalebar' object, e.g:

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -7,6 +7,7 @@ import FigureLutPicker from "../views/lutpicker";
 import FigureColorPicker from "../views/colorpicker";
 
 import channel_slider_template from '../../templates/channel_slider.template.html?raw';
+import checkbox_template from '../../templates/checkbox_template.html?raw';
 
 import lutsPng from "../../images/luts_10.png";
 // Need to handle dev vv built (omero-web) paths
@@ -27,11 +28,12 @@ function debounce(func, wait) {
 var ChannelSliderView = Backbone.View.extend({
 
     template: _.template(channel_slider_template),
+    checkboxTemplate: _.template(checkbox_template),
 
     initialize: function(opts) {
         // This View may apply to a single PanelModel or a list
         this.models = opts.models;
-        this.checkboxChecked = false;
+        // this.checkboxChecked = false;
         var self = this;
         this.models.forEach(function(m){
             self.listenTo(m, 'change:channels', self.render);
@@ -47,7 +49,7 @@ var ChannelSliderView = Backbone.View.extend({
         "change .ch_slider input": "channel_slider_stop",
         "mousemove .ch_start_slider": "start_slider_mousemove",
         "mousemove .ch_end_slider": "end_slider_mousemove",
-        "change #hilo-checkbox": "handle_hilo_checkbox", // Add the change event
+        "change #hiloCheckbox": "handle_hilo_checkbox", // Add the change event
     },
 
     start_slider_mousemove: function(event) {
@@ -279,7 +281,7 @@ var ChannelSliderView = Backbone.View.extend({
         return this;
     },
 
-    handle_hilo_checkbox: debounce(function(event) {
+    handle_hilo_checkbox: function(event) {
         var self = this;
     
         // Check if the checkbox is checked
@@ -306,10 +308,8 @@ var ChannelSliderView = Backbone.View.extend({
                     m.save_channel(channelIdx, 'color', self.originalColors[modelIdx][channelIdx]);
                 });
             });
-            // Uncheck the checkbox
-            $('#hilo-checkbox').prop('checked', false);
         }
-    }, 100),  
+    }, 
 
     render: function() {
         var json,
@@ -435,15 +435,13 @@ var ChannelSliderView = Backbone.View.extend({
 
             }.bind(this));
 
-            var checkboxHtml = '<div class="checkbox-container">' +
-                       '<input type="checkbox" id="hilo-checkbox" name="hilo-checkbox">' +
-                       '<label for="hilo-checkbox">  Hilo</label>' +
-                       '</div>';
+            // Append the checkbox template
+            var checkboxHtml = this.checkboxTemplate();
             this.$el.append(checkboxHtml);
 
             // Check if the checkbox should be checked based on the current state
             if (this.checkboxChecked) {
-                $('#hilo-checkbox').prop('checked', true);
+                $('#hiloCheckbox').prop('checked', true);
             }
 
         return this;

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -308,6 +308,9 @@ var ChannelSliderView = Backbone.View.extend({
     loadCheckboxState: function() {
         var checkbox = this.$("#hiloCheckbox")[0];
         this.models.forEach(function(m) {
+            if(m.get('hilo_enabled') === undefined ){
+                m.set('hilo_enabled', false);
+            }
             checkbox.checked = m.get('hilo_enabled');
         });
     },

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -311,7 +311,7 @@ var ChannelSliderView = Backbone.View.extend({
             if(m.get('hilo_enabled') === undefined ){
                 m.set('hilo_enabled', false);
             }
-            checkbox.checked = m.get('hilo_enabled');
+            checkbox.checked = m.get('hilo_enabled') || checkbox.checked;
         });
     },
 

--- a/src/js/views/channel_slider_view.js
+++ b/src/js/views/channel_slider_view.js
@@ -16,15 +16,6 @@ const lutsPngUrl = STATIC_DIR + lutsPng;
 const SLIDER_INCR_CUTOFF = 100;
 // If the max value of a slider is below this, use smaller slider increments
 
-function debounce(func, wait) {
-    let timeout;
-    return function() {
-        const context = this, args = arguments;
-        clearTimeout(timeout);
-        timeout = setTimeout(() => func.apply(context, args), wait);
-    };
-}
-
 var ChannelSliderView = Backbone.View.extend({
     
     template: _.template(channel_slider_template),
@@ -33,12 +24,10 @@ var ChannelSliderView = Backbone.View.extend({
     initialize: function(opts) {
         // This View may apply to a single PanelModel or a list
         this.models = opts.models;
-        // this.checkboxChecked = false;
         var self = this;
         this.models.forEach(function(m){
             self.listenTo(m, 'change:channels', self.render);
         });
-        //this.loadCheckboxState();
     },
 
     events: {
@@ -283,25 +272,24 @@ var ChannelSliderView = Backbone.View.extend({
     },
 
     handle_hilo_checkbox: function(event) {
-        var checkbox = event.target;
-        var checkboxState = checkbox.checked;
+        var checkboxState = event.target.checked;
         this.models.forEach(function(m) {
             if (checkboxState && !m.get("hilo_enabled")){
                 // enable Hilo for Panel
                 m.set("hilo_enabled", true);
                 m.set("hilo_original_colors", m.get('channels').map(function(channel) {
                     return channel.color;
-                }));
+                }));                
                 m.get('channels').forEach(function(channel, idx) {
                     m.save_channel(idx, 'color', 'hilo.lut');
-                });                
+                });                           
             } else if (!checkboxState && m.get("hilo_enabled")){
                 // remove hilo state
                 m.set("hilo_enabled", false);
                 m.get('channels').forEach(function(channel, idx) {
                     m.save_channel(idx, 'color', m.get("hilo_original_colors")[idx]);
                 });   
-            } 
+            }
         })
     },  
 
@@ -357,7 +345,6 @@ var ChannelSliderView = Backbone.View.extend({
                     return fn(prev, curr);
                 }
             }
-
             // Comare channels from each Panel Model to see if they are
             // compatible, and compile a summary json.
             var chData = this.models.map(function(m){
@@ -367,13 +354,11 @@ var ChannelSliderView = Backbone.View.extend({
             var allSameCount = chData.reduce(function(prev, channels){
                 return channels.length === prev ? prev : false;
             }, chData[0].length);
-
             if (!allSameCount) {
                 return this;
             }
             // $(".ch_slider").slider("destroy");
             this.$el.empty();
-
             chData[0].forEach(function(d, chIdx) {
                 // For each channel, summarise all selected images:
                 // Make list of various channel attributes:
@@ -438,11 +423,9 @@ var ChannelSliderView = Backbone.View.extend({
                 $(sliderHtml).appendTo(this.$el);
 
             }.bind(this));
-
             // Append the checkbox template
             var checkboxHtml = this.checkboxTemplate();
             this.$el.append(checkboxHtml);
-
             // Load checkbox state after rendering
             this.loadCheckboxState();
         return this;

--- a/src/templates/checkbox_template.html
+++ b/src/templates/checkbox_template.html
@@ -1,0 +1,4 @@
+<div class="checkbox-container">
+    <input type="checkbox" id="hiloCheckbox" name="hiloCheckbox">
+    <label for="hiloCheckbox">  Hilo</label>
+</div>


### PR DESCRIPTION
Hello,
I've implemented a new feature to add a Hilo checkbox to the channel slider view. 

This checkbox allows users to rapidly toggle the Hilo LU across all channels. 

When the checkbox is checked, the Hilo LUT (hilo.lut) is applied to all channels, and when unchecked, the original colors are restored.


Please review the changes, and feel free to provide any feedback or suggestions.

Mina

@Tom-TBT 