### PR TITLE
implemented get_timestamps() from timeIncrement attribute

### DIFF
--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -44,6 +44,7 @@ def get_timestamps(conn, image):
     if len(info_list) == 0 or len(timemap) == 0:
         # get time info from the timeIncrement of the Pixels
         time_increment = 0
+        converted_value = 0
         try:
             pixels = image.getPrimaryPixels()._obj
             time_increment = pixels.getTimeIncrement()

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -48,9 +48,9 @@ def get_timestamps(conn, image):
         try:
             pixels = image.getPrimaryPixels()._obj
             time_increment = pixels.getTimeIncrement()
-            time_increment_unit = time_increment.getUnit()
-            converted_value = TimeI.CONVERSIONS[time_increment_unit][
-                UnitsTime.SECOND](time_increment._value)
+            secs_unit = getattr(UnitsTime, "SECOND")
+            seconds = TimeI(time_increment, secs_unit)
+            converted_value = seconds.getValue()
 
         except Exception as error:
             print(f"An exception occured: {error}\n"

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -38,7 +38,8 @@ def get_timestamps(conn, image):
                 plane_info = PlaneInfoWrapper(conn, info)
                 delta_t = plane_info.getDeltaT('SECOND')
                 timemap[t_index] = delta_t.getValue()
-    else:
+    # double check to see if timemap actually got populated
+    if len(info_list) == 0 or len(timemap) == 0:
         # get time info from the timeIncrement of the Pixels
         time_increment = 0
         try:

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -17,6 +17,8 @@
 
 from omero.sys import ParametersI
 from omero.gateway import PlaneInfoWrapper
+from omero.model.enums import UnitsTime
+from omero.model import TimeI
 
 
 def get_timestamps(conn, image):
@@ -44,13 +46,18 @@ def get_timestamps(conn, image):
         time_increment = 0
         try:
             pixels = image.getPrimaryPixels()._obj
-            time_increment = pixels.getTimeIncrement()._value
+            time_increment = pixels.getTimeIncrement()
+            time_increment_unit = time_increment.getUnit()
+            converted_value = TimeI.CONVERSIONS[time_increment_unit][
+                UnitsTime.SECOND](time_increment._value)
+            converted_time_increment = TimeI(converted_value, UnitsTime.SECOND)
+
         except Exception as error:
             print(f"An exception occured: {error}\n"
                   "maybe the image has no 'timeIncrement' set")
-        if time_increment != 0:
+        if converted_time_increment != 0:
             for i in range(image.getSizeT()):
-                timemap[i] = i*time_increment
+                timemap[i] = i*converted_time_increment
     time_list = []
     for t in range(image.getSizeT()):
         if t in timemap:

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -48,8 +48,9 @@ def get_timestamps(conn, image):
         except Exception as error:
             print(f"An exception occured: {error}\n"
                   "maybe the image has no 'timeIncrement' set")
-        for i in range(image.getSizeT()):
-            timemap[i] = i*time_increment
+        if time_increment != 0:
+            for i in range(image.getSizeT()):
+                timemap[i] = i*time_increment
     time_list = []
     for t in range(image.getSizeT()):
         if t in timemap:

--- a/omero_figure/omeroutils.py
+++ b/omero_figure/omeroutils.py
@@ -50,14 +50,13 @@ def get_timestamps(conn, image):
             time_increment_unit = time_increment.getUnit()
             converted_value = TimeI.CONVERSIONS[time_increment_unit][
                 UnitsTime.SECOND](time_increment._value)
-            converted_time_increment = TimeI(converted_value, UnitsTime.SECOND)
 
         except Exception as error:
             print(f"An exception occured: {error}\n"
                   "maybe the image has no 'timeIncrement' set")
-        if converted_time_increment != 0:
+        if converted_value != 0:
             for i in range(image.getSizeT()):
-                timemap[i] = i*converted_time_increment
+                timemap[i] = i*converted_value
     time_list = []
     for t in range(image.getSizeT()):
         if t in timemap:


### PR DESCRIPTION
Changed `get_timestamps()` to revert back to the `timeIncrement` attribute of `Pixels` of an `Image`, if no `PlaneInfo` is found for it, or if the `PlaneInfo` did not contain `DeltaT` information.
If no `timeIncrement` attribute is found, it will just return 0 for all timepoints.
This does not account for any time offset that might have occured, i.e. the first image always is at 0s.
