### PR TITLE
Filter owners and groups dropdown lists

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1019,7 +1019,7 @@
       role="dialog"
       aria-hidden="true"
     >
-      <div class="modal-dialog modal-lg">
+      <div class="modal-dialog modal-lg" style="--bs-modal-width: 900px">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title">Open</h5>
@@ -1035,8 +1035,8 @@
             <table class="table table-sm">
               <thead>
                 <tr>
-                  <th style="width: 7%"></th>
-                  <th style="width: 45%">
+                  <th></th>
+                  <th>
                     <form class="row" role="form">
                       <div class="col-auto">
                         <label class="col-sm-2 control-label">Name</label>
@@ -1062,8 +1062,8 @@
                       </div>
                     </form>
                   </th>
-                  <th style="width: 25%">
-                    <form class="row" role="form">
+                  <th>
+                    <form class="row" role="form" style="flex-wrap: nowrap;">
                       <div class="col-auto">
                         <label class="col-sm-2 control-label">Created</label>
                       </div>
@@ -1081,10 +1081,11 @@
                       </button>
                     </form>
                   </th>
-                  <th style="width: 12%">
+                  <th>
                     Owner:
                     <div class="btn-group" title="Filter files by owner">
                       <button
+                        style="max-width: 120px; overflow: hidden;"
                         type="button"
                         class="btn dropdown-toggle btn-outline-secondary"
                         data-bs-toggle="dropdown"
@@ -1100,10 +1101,11 @@
                       </ul>
                     </div>
                   </th>
-                  <th style="width: 12%">
+                  <th>
                     Group:
                     <div class="btn-group" title="Filter files by group">
                       <button
+                        style="max-width: 120px; overflow: hidden;"
                         type="button"
                         class="btn dropdown-toggle btn-outline-secondary"
                         data-bs-toggle="dropdown"

--- a/src/index.html
+++ b/src/index.html
@@ -1082,26 +1082,6 @@
                     </form>
                   </th>
                   <th>
-                    Owner:
-                    <div class="btn-group" title="Filter files by owner">
-                      <button
-                        style="max-width: 120px; overflow: hidden;"
-                        type="button"
-                        class="btn dropdown-toggle btn-outline-secondary"
-                        data-bs-toggle="dropdown"
-                      >
-                        <span id="selected_owner">Owner</span> <span class="caret"></span>
-                      </button>
-                      <ul
-                        id="owner-menu"
-                        class="dropdown-menu float-end"
-                        role="menu"
-                      >
-                        <!-- owners added here -->
-                      </ul>
-                    </div>
-                  </th>
-                  <th>
                     Group:
                     <div class="btn-group" title="Filter files by group">
                       <button
@@ -1118,6 +1098,26 @@
                         role="menu"
                       >
                         <!-- groups added here -->
+                      </ul>
+                    </div>
+                  </th>
+                  <th>
+                    Owner:
+                    <div class="btn-group" title="Filter files by owner">
+                      <button
+                        style="max-width: 120px; overflow: hidden;"
+                        type="button"
+                        class="btn dropdown-toggle btn-outline-secondary"
+                        data-bs-toggle="dropdown"
+                      >
+                        <span id="selected_owner">Owner</span> <span class="caret"></span>
+                      </button>
+                      <ul
+                        id="owner-menu"
+                        class="dropdown-menu float-end"
+                        role="menu"
+                      >
+                        <!-- owners added here -->
                       </ul>
                     </div>
                   </th>

--- a/src/index.html
+++ b/src/index.html
@@ -1082,13 +1082,14 @@
                     </form>
                   </th>
                   <th style="width: 12%">
+                    Owner:
                     <div class="btn-group" title="Filter files by owner">
                       <button
                         type="button"
-                        class="btn dropdown-toggle"
+                        class="btn dropdown-toggle btn-outline-secondary"
                         data-bs-toggle="dropdown"
                       >
-                        <b>Owner</b> <span class="caret"></span>
+                        <span id="selected_owner">Owner</span> <span class="caret"></span>
                       </button>
                       <ul
                         id="owner-menu"
@@ -1100,13 +1101,14 @@
                     </div>
                   </th>
                   <th style="width: 12%">
+                    Group:
                     <div class="btn-group" title="Filter files by group">
                       <button
                         type="button"
-                        class="btn dropdown-toggle"
+                        class="btn dropdown-toggle btn-outline-secondary"
                         data-bs-toggle="dropdown"
                       >
-                        <b>Group</b> <span class="caret"></span>
+                        <span id="selected_group">Group</span> <span class="caret"></span>
                       </button>
                       <ul
                         id="group-menu"

--- a/src/index.html
+++ b/src/index.html
@@ -1082,7 +1082,7 @@
                     </form>
                   </th>
                   <th>
-                    Group:
+                    Group:<br>
                     <div class="btn-group" title="Filter files by group">
                       <button
                         style="max-width: 120px; overflow: hidden;"
@@ -1102,7 +1102,7 @@
                     </div>
                   </th>
                   <th>
-                    Owner:
+                    Owner:<br>
                     <div class="btn-group" title="Filter files by owner">
                       <button
                         style="max-width: 120px; overflow: hidden;"

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -44,7 +44,7 @@ export var FigureFile = Backbone.Model.extend({
     },
 
     isVisible: function(filter) {
-        if (filter.owner) {
+        if (filter.owner !== undefined) {
             if (this.get('owner').id !== filter.owner) {
                 return false;
             }
@@ -232,7 +232,7 @@ export var FileListView = Backbone.View.extend({
             filter = {},
             filterVal = this.$fileFilter.val(),
             currentFileId = this.figureModel.get('fileId');
-        if (this.owner && this.owner != -1) {
+        if (this.owner !== undefined && this.owner != -1) {
             filter.owner = this.owner;
         }
         if (this.group && this.group != -1) {

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -284,6 +284,9 @@ export var FileListView = Backbone.View.extend({
                 </a></li>`;
         });
         $("#owner-menu").html(ownersHtml);
+        let owner = owners.find(o => o.id == filter.owner);
+        let ownerName = owner ? `${owner.firstName} ${owner.lastName}`: "Show All";
+        $("#selected_owner").html(ownerName);
 
         // render groups chooser
         var groups = this.model.pluck("group");
@@ -304,6 +307,9 @@ export var FileListView = Backbone.View.extend({
                 ${_.escape(name)}
             </a></li>`).join('\n');
         $("#group-menu").html(groupsHtml);
+        let group = groups.find(g => g.id == filter.group);
+        let groupName = group ? group.name: "Show All";
+        $("#selected_group").html(groupName);
         return this;
     }
 });

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -290,10 +290,6 @@ export var FileListView = Backbone.View.extend({
 
         // render groups chooser
         var groups = this.model.pluck("group");
-        if (filter.owner) {
-            let groupIds = this.model.models.filter(f => f.get('owner').id == filter.owner).map(f => f.get('group').id);
-            groups = groups.filter(g => groupIds.includes(g.id));
-        }
         var groupsByName = {};
         groups.forEach(function (g) {
             groupsByName[g.name] = g.id;

--- a/src/js/views/files.js
+++ b/src/js/views/files.js
@@ -256,6 +256,10 @@ export var FileListView = Backbone.View.extend({
             self.$tbody.prepend(e);
         });
         var owners = this.model.pluck("owner");
+        // Lookup owner by ID "before" filtering, in case the chosen owner is filtered out
+        let owner = owners.find(o => o.id == filter.owner);
+        let ownerName = owner ? `${owner.firstName} ${owner.lastName}`: "Show All";
+
         if (filter.group) {
             let ownerIds = this.model.models.filter(f => f.get('group').id == filter.group).map(f => f.get('owner').id);
             owners = owners.filter(o => ownerIds.includes(o.id));
@@ -284,8 +288,6 @@ export var FileListView = Backbone.View.extend({
                 </a></li>`;
         });
         $("#owner-menu").html(ownersHtml);
-        let owner = owners.find(o => o.id == filter.owner);
-        let ownerName = owner ? `${owner.firstName} ${owner.lastName}`: "Show All";
         $("#selected_owner").html(ownerName);
 
         // render groups chooser

--- a/src/templates/files/figure_file_item.template.html
+++ b/src/templates/files/figure_file_item.template.html
@@ -25,8 +25,8 @@
         <%= formatDate(creationDate) %>
     </td>
     <td>
-        <%- ownerFullName %>
+        <%- group.name %>
     </td>
     <td>
-        <%- group.name %>
+        <%- ownerFullName %>
     </td>


### PR DESCRIPTION
See https://forum.image.sc/t/omero-figure-filtering-users-by-group/101933

When you filter the File > Open list by a Group, the owners list is also filtered to only show Owners within that Group.
Also, the columns now show the current status of Filtering:

![Screenshot 2024-12-03 at 14 24 15](https://github.com/user-attachments/assets/3ffab432-76e1-40e2-8914-572725934842)

This PR changes the display of the Owners menu in the File choose dialog. It does not change the actual behaviour of filtering Files.
To clarify the changes in this PR, I'll compare the behaviour BEFORE and AFTER...
NB: The Groups and Owners menus are only populated based on the Groups and Owners of the Figures you can access (that are loaded in the Files dialog). They are not generated based on Groups and Owners listed from OMERO. We also have no info on who is an Admin, so all users will get the same behaviour.

BEFORE:

 - Initially the default filtering is to filter by Owner = YOU and ALL Groups.
 - The Owner drop-down menu would contain All users and the Groups drop-down menu would also contain All Groups that contain Figures (regardless of whether YOU own any Figures in those groups).
 
![Screenshot 2024-11-28 at 11 28 55](https://github.com/user-attachments/assets/ec08b95f-f941-46af-824d-c5de9e4012a9)

 - If you choose to filter by a Group where you have NO Figures, you will see NO Figures.
 - To find Figures that belong to another user, you will first have to Filter by that Owner, then (optionally) filter by Group.

AFTER:
 - Initially the default filtering is to filter by Owner = YOU and ALL Groups. (No Change)
 - The Owner drop-down menu initially contains All users, since we are filtering by ALL groups (No Change). The Groups menu also shows ALL groups that contain figures (No Change)
 - Now, when you filter by Group, the Owners menu only shows users who own figures in that Group.


 - To find Figures that belong to another user, you can directly filter by that Owner (No Change), or filter by Group to reduce the number of Owners, then filter by Owner.
 - If someone (E.g. a PI) wants to find figures belonging to a member of his/her Group, they can filter first by that Group, then choose to filter by Owner (which now ONLY shows owners in the selected Group). Previously this owner list still listed ALL owners.
