### PR TITLE
Inset bugfixes

### DIFF
--- a/src/js/models/panel_model.js
+++ b/src/js/models/panel_model.js
@@ -102,7 +102,12 @@
                     // delete or update the "inset" Rectangle
                     let updated = this.get('shapes');
                     if (panelDeleted) {
-                        updated = updated.filter(shape => shape.id != insetRoiId);
+                        // Delete the inset Rectangle IF there are NO other remaining insets
+                        let insets = figureModel.panels.filter(p => p.get('insetRoiId') == insetRoiId);
+                        if (insets.length == 0) {
+                            updated = updated.filter(shape => shape.id != insetRoiId);
+                        }
+                        this.save('shapes', updated);
                     } else {
                         let rect = panel.getViewportAsRect();
                         updated = updated.map(shape => {
@@ -111,8 +116,8 @@
                             }
                             return shape;
                         });
+                        this.save('shapes', updated);
                     }
-                    this.save('shapes', updated);
                     this.silenceTriggers = false;
                 }
             }

--- a/src/js/views/util.js
+++ b/src/js/views/util.js
@@ -267,10 +267,6 @@ export function getRandomId() {
     return parseInt(Math.random() * RANDOM_NUMBER_RANGE);
 }
 
-export function newIdFromRandomId(oldId) {
-    return parseInt((oldId * Math.PI) % RANDOM_NUMBER_RANGE);
-}
-
 export function updateRoiIds(panelsJson) {
     // If we copy and paste an inset panel AND it's corresponding panel with Rect,
     // we don't want changes in viewport/Rect to trigger changes in the panels they
@@ -296,14 +292,15 @@ export function updateRoiIds(panelsJson) {
     let idsToUpdate = insetIdsFromPanels.filter(roiId => insetIdsFromShapes.includes(roiId));
 
     // Update the IDs
+    let toAdd = getRandomId();
     let updatedPanels = panelsJson.map(panelJson => {
         if (idsToUpdate.includes(panelJson.insetRoiId)) {
-            panelJson.insetRoiId = newIdFromRandomId(panelJson.insetRoiId);
+            panelJson.insetRoiId = (panelJson.insetRoiId + toAdd) % RANDOM_NUMBER_RANGE;
         }
         if (panelJson.shapes) {
             panelJson.shapes.forEach(shape => {
                 if (idsToUpdate.includes(shape.id)) {
-                    shape.id = newIdFromRandomId(shape.id);
+                    shape.id = (shape.id + toAdd) % RANDOM_NUMBER_RANGE;
                 }
             });
         }


### PR DESCRIPTION
Fixes #601 

Test bug-fix 1:

 - Select a panel and use the "Inset" button to create an Inset
 - Copy and paste the newly created Inset panel to duplicate it
 - Now delete ONE of the 2 inset panels. The inset ROI shouldn't be deleted.
 - If you delete the other inset panel the inset ROI should be deleted as before.

Test bug-fix 2:

  - Select a panel and use the "Inset" button to create an Inset
  - Select both the original panel and the new inset panel.
  - Copy and Paste to duplicate the pair of panels
  - Repeat the copy and paste to duplicate the 2 panels again.
  - Check that each inset ROI is only "linked" to it's corresponding inset panel (that was duplicated at the same time).
 
<img width="339" alt="Screenshot 2024-11-28 at 21 59 52" src="https://github.com/user-attachments/assets/4b57548d-98ce-417a-8220-09fe63c27ca0">
