### PR TITLE
Script version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -20,3 +20,5 @@ values =
 [bumpversion:file:omero_figure/utils.py]
 
 [bumpversion:file:src/.env]
+
+[bumpversion:file:omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py]

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2721,7 +2721,11 @@ def run_script():
                        description="Name of the Pdf Figure"),
 
         scripts.String("Figure_URI",
-                       description="URL to the Figure")
+                       description="URL to the Figure"),
+
+        # This allows clients to query the script version
+        # by listing script params and getting default value
+        scripts.String("FIGURE_VERSION", default=VERSION)
     )
 
     try:

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -67,7 +67,7 @@ except ImportError:
     reportlab_installed = False
     logger.error("Reportlab not installed.")
 
-VERSION="7.2.2.dev0"
+VERSION = "7.2.2.dev0"
 DEFAULT_OFFSET = 0
 
 ORIGINAL_DIR = "1_originals"

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -67,6 +67,7 @@ except ImportError:
     reportlab_installed = False
     logger.error("Reportlab not installed.")
 
+VERSION="7.2.2.dev0"
 DEFAULT_OFFSET = 0
 
 ORIGINAL_DIR = "1_originals"

--- a/omero_figure/urls.py
+++ b/omero_figure/urls.py
@@ -42,6 +42,9 @@ urlpatterns = [
     path('make_web_figure/', views.make_web_figure,
          name='make_web_figure'),
 
+    path('upload_omero_script/', views.upload_omero_script,
+         name="figure_upload_omero_script"),
+
     # Save json to file annotation
     path('save_web_figure/', views.save_web_figure, name='save_web_figure'),
 

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -94,7 +94,7 @@ def index(request, file_id=None, conn=None, **kwargs):
             for key, param in params.inputs.items():
                 if (key == "FIGURE_VERSION"):
                     script_version = unwrap(param.prototype)
-        except Exception as ex:
+        except Exception:
             logger.debug(traceback.format_exc())
 
     user = conn.getUser()
@@ -692,7 +692,7 @@ def upload_omero_script(request, conn=None, **kwargs):
     try:
         with open(script_path) as script_file:
             script_text = script_file.read()
-    except Exception as ex:
+    except Exception:
         logger.debug(traceback.format_exc())
         return JsonResponse({"Message": "Failed to load script"})
 
@@ -703,7 +703,8 @@ def upload_omero_script(request, conn=None, **kwargs):
             script_service.editScript(orig_file, script_text)
             message = "Script Replaced"
         else:
-            script_id = script_service.uploadOfficialScript(SCRIPT_PATH, script_text)
+            script_id = script_service.uploadOfficialScript(
+                SCRIPT_PATH, script_text)
             message = "Script Uploaded"
     except omero.ValidationException as ex:
         message = str(ex)

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.template import loader
 from django.templatetags import static
 from datetime import datetime
+import os
 import traceback
 import json
 import time
@@ -86,7 +87,18 @@ def index(request, file_id=None, conn=None, **kwargs):
     script_service = conn.getScriptService()
     sid = script_service.getScriptID(SCRIPT_PATH)
     export_enabled = sid > 0
+    script_version = None
+    if export_enabled:
+        try:
+            params = script_service.getParams(sid)
+            for key, param in params.inputs.items():
+                if (key == "FIGURE_VERSION"):
+                    script_version = unwrap(param.prototype)
+        except Exception as ex:
+            logger.debug(traceback.format_exc())
+
     user = conn.getUser()
+    is_admin = conn.isAdmin()
     user_full_name = "%s %s" % (user.firstName, user.lastName)
     max_w, max_h = conn.getMaxPlaneSize()
     max_plane_size = max_w * max_h
@@ -125,6 +137,11 @@ def index(request, file_id=None, conn=None, **kwargs):
     if export_enabled:
         html = html.replace('const EXPORT_ENABLED = false;',
                             'const EXPORT_ENABLED = true;')
+        html = html.replace('const SCRIPT_VERSION = "";',
+                            f'const SCRIPT_VERSION = "{script_version}"')
+    if is_admin:
+        html = html.replace('const IS_ADMIN = false;',
+                            'const IS_ADMIN = true;')
 
     # update links to static files
     static_dir = static.static('omero_figure/')
@@ -657,6 +674,41 @@ def make_web_figure(request, conn=None, **kwargs):
 
     rsp = run_script(request, conn, sid, input_map, scriptName='Figure.pdf')
     return HttpResponse(json.dumps(rsp), content_type='json')
+
+
+@login_required(isAdmin=True)
+def upload_omero_script(request, conn=None, **kwargs):
+    """Uploads or Replaces the Figure_To_Pdf.py"""
+
+    if not request.method == 'POST':
+        return HttpResponse("Need to use POST")
+
+    script_service = conn.getScriptService()
+    script_id = script_service.getScriptID(SCRIPT_PATH)
+
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    script_path = os.path.join(this_dir, "scripts", SCRIPT_PATH[1:])
+
+    try:
+        with open(script_path) as script_file:
+            script_text = script_file.read()
+    except Exception as ex:
+        logger.debug(traceback.format_exc())
+        return JsonResponse({"Message": "Failed to load script"})
+
+    # If script exists, replace. Otherwise upload
+    try:
+        if script_id > 0:
+            orig_file = omero.model.OriginalFileI(script_id, False)
+            script_service.editScript(orig_file, script_text)
+            message = "Script Replaced"
+        else:
+            script_id = script_service.uploadOfficialScript(SCRIPT_PATH, script_text)
+            message = "Script Uploaded"
+    except omero.ValidationException as ex:
+        message = str(ex)
+
+    return JsonResponse({"Message": message, "script_id": script_id})
 
 
 @login_required()

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -694,7 +694,8 @@ def upload_omero_script(request, conn=None, **kwargs):
             script_text = script_file.read()
     except Exception:
         logger.debug(traceback.format_exc())
-        return JsonResponse({"Message": "Failed to load script"})
+        return JsonResponse({
+            "Error": "Failed to load script from " + script_path})
 
     # If script exists, replace. Otherwise upload
     try:
@@ -707,7 +708,7 @@ def upload_omero_script(request, conn=None, **kwargs):
                 SCRIPT_PATH, script_text)
             message = "Script Uploaded"
     except omero.ValidationException as ex:
-        message = str(ex)
+        return JsonResponse({"Error": ex.message})
 
     return JsonResponse({"Message": message, "script_id": script_id})
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,15 @@
         "@popperjs/core": "^2.11.5",
         "backbone": "^1.4.1",
         "bootstrap": "^5.2.0",
-        "bootstrap-icons": "^1.9.1",
+        "bootstrap-icons": "^1.11.0",
         "dompurify": "^2.5.4",
         "jquery": "^3.6.0",
         "marked": "^4.2.12",
         "mousetrap": "^1.6.5",
         "raphael": "^2.3.0",
         "sortablejs": "^1.15.2",
-        "underscore": "^1.13.4"
+        "underscore": "^1.13.4",
+        "vite-plugin-html-inject": "^1.1.2"
       },
       "devDependencies": {
         "sass": "^1.54.1",
@@ -667,9 +668,19 @@
       }
     },
     "node_modules/bootstrap-icons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
-      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ]
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1108,6 +1119,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-plugin-html-inject": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-html-inject/-/vite-plugin-html-inject-1.1.2.tgz",
+      "integrity": "sha512-4DWANEcAw73H5JLWTAI4EvXdSyoGqGq/Is9fTRjpF+SJLor58LNdqB+YYnK3FOLwx6LMTAn4z1hkiRyc52lYLg=="
     },
     "node_modules/watch": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mousetrap": "^1.6.5",
     "raphael": "^2.3.0",
     "sortablejs": "^1.15.2",
-    "underscore": "^1.13.4"
+    "underscore": "^1.13.4",
+    "vite-plugin-html-inject": "^1.1.2"
   }
 }

--- a/src/css/figure.css
+++ b/src/css/figure.css
@@ -999,7 +999,7 @@
         100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); }
     }
 
-    .navbar .bi-arrow-repeat, .imgContainer .bi-arrow-repeat {
+    .navbar .bi-arrow-repeat, .imgContainer .bi-arrow-repeat, .spinner {
         animation: spin 2s linear infinite;
         display: inline-block;
     }

--- a/src/html/dialogs/scriptManagerDialog.html
+++ b/src/html/dialogs/scriptManagerDialog.html
@@ -1,0 +1,65 @@
+<div
+  class="modal"
+  id="scriptManagerDialog"
+  tabindex="-1"
+  role="dialog"
+  aria-hidden="true"
+>
+  <div class="modal-dialog" style="width: 400px">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Script Version Warning</h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p>
+          Your figure export script version is
+          <code id="export_script_version">Unknown</code>.
+        </p>
+        <p>
+          Your OMERO.figure app version is
+          <code id="figure_app_version">Unknown</code>.
+        </p>
+
+        <div class="alert alert-danger" role="alert">
+          Your Figure may not be correctly exported to PDF or TIFF when using an
+          older version of the export script.
+        </div>
+
+        <!-- Alternative messages depending whether user isAdmin.
+         1 of these is shown when the dialog is opened -->
+        <!-- if NOT Admin -->
+        <p id="non_admin_script_message" style="display: none">
+          Users must have <code>Admin</code> permissions in order to update the
+          script.
+        </p>
+        <!-- if Admin -->
+        <div id="admin_script_message" style="display: none">
+          <p>
+            You have <code>Admin</code> permissions and can update the script on
+            the OMERO server.
+          </p>
+          <p>
+            <button
+              type="button"
+              data-export-option="PDF"
+              class="btn btn-success btn-sm float-end upload_omero_script"
+            >
+              Update Script
+            </button>
+          </p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">
+          OK
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/html/dialogs/scriptManagerDialog.html
+++ b/src/html/dialogs/scriptManagerDialog.html
@@ -8,7 +8,11 @@
   <div class="modal-dialog" style="width: 400px">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Script Version Warning</h5>
+        <!-- When this dialog is shown in script_version_warning() we show/hide sections... -->
+        <!-- All the .script_version_mismatch sections are shown if script exists (but outdated) -->
+        <h5 class="script_version_mismatch" class="modal-title">Script Version Warning</h5>
+        <!-- All the .script_missing sections are shown if script is missing -->
+        <h5 class="script_missing" class="modal-title">Export Script not on OMERO.server</h5>
         <button
           type="button"
           class="btn-close"
@@ -17,18 +21,27 @@
         ></button>
       </div>
       <div class="modal-body">
-        <p>
-          Your figure export script version is
-          <code id="export_script_version">Unknown</code>.
-        </p>
-        <p>
-          Your OMERO.figure app version is
-          <code id="figure_app_version">Unknown</code>.
-        </p>
 
-        <div class="alert alert-danger" role="alert">
-          Your Figure may not be correctly exported to PDF or TIFF when using an
-          older version of the export script.
+        <div class="script_version_mismatch">
+          <p>
+            Your figure export script version is
+            <code id="export_script_version">Unknown</code>.
+          </p>
+          <p>
+            Your OMERO.figure app version is
+            <code id="figure_app_version">Unknown</code>.
+          </p>
+
+          <div class="alert alert-danger" role="alert">
+            Your Figure may not be correctly exported to PDF or TIFF when using an
+            older version of the export script.
+          </div>
+        </div>
+
+        <div class="script_missing">
+          <div class="alert alert-danger" role="alert">
+            The Figure Export Script is not available on the OMERO server.
+          </div>
         </div>
 
         <!-- Alternative messages depending whether user isAdmin.
@@ -41,18 +54,26 @@
         <!-- if Admin -->
         <div id="admin_script_message" style="display: none">
           <p>
-            You have <code>Admin</code> permissions and can update the script on
-            the OMERO server.
+            You have <code>Admin</code> permissions and can
+            <span class="script_missing">upload</span>
+            <span class="script_version_mismatch">update</span>
+            the script on the OMERO server.
           </p>
-          <p>
+          <p style="text-align: right;">
             <button
               type="button"
               data-export-option="PDF"
-              class="btn btn-success float-end upload_omero_script"
+              class="btn btn-success upload_omero_script"
             >
-              Update Script
+              <span class="script_missing">Upload Script</span>
+              <span class="script_version_mismatch">Update Script</span>
+              <i class="bi-arrow-repeat spinner" style="display: none"></i>
             </button>
           </p>
+          <div id="script_upload_message" class="alert alert-success" role="alert"
+               style="display: none">
+            <!-- Script upload response message goes here -->
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/html/dialogs/scriptManagerDialog.html
+++ b/src/html/dialogs/scriptManagerDialog.html
@@ -36,7 +36,7 @@
         <!-- if NOT Admin -->
         <p id="non_admin_script_message" style="display: none">
           Users must have <code>Admin</code> permissions in order to update the
-          script.
+          script. Please contact your OMERO server administrator.
         </p>
         <!-- if Admin -->
         <div id="admin_script_message" style="display: none">
@@ -48,7 +48,7 @@
             <button
               type="button"
               data-export-option="PDF"
-              class="btn btn-success btn-sm float-end upload_omero_script"
+              class="btn btn-success float-end upload_omero_script"
             >
               Update Script
             </button>

--- a/src/index.html
+++ b/src/index.html
@@ -1575,14 +1575,6 @@
                 <i class="bi-exclamation-triangle"></i>
             </a>
 
-            <!-- <button
-              type="button"
-              style="display: none"
-              class="btn btn-danger btn-sm"
-            >
-              <i class="bi-exclamation-triangle"></i>
-            </button> -->
-
             <div class="btn-group">
               <!-- button enabled if EXPORT_ENABLED is true -->
               <button

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
       const BASE_OMEROWEB_URL = dev_omeroweb_url;
       const EXPORT_ENABLED = false;
       const SCRIPT_VERSION = "";
-      const IS_ADMIN = true;
+      const IS_ADMIN = false;
       const WEBINDEX_URL = BASE_OMEROWEB_URL + "webclient/";
       const BASE_WEBFIGURE_URL = BASE_OMEROWEB_URL + "figure/";
       const WEBGATEWAYINDEX = BASE_OMEROWEB_URL + "webgateway/";
@@ -1584,13 +1584,6 @@
             </button> -->
 
             <div class="btn-group">
-              <button
-                title="Wrong script version!"
-                type="button"
-                class="btn btn-danger btn-sm script_version_warning"
-              >
-                <i class="bi-exclamation-circle"></i>
-              </button>
               <!-- button enabled if EXPORT_ENABLED is true -->
               <button
                 type="button"
@@ -1599,6 +1592,13 @@
                 class="btn btn-success btn-sm export_pdf"
               >
                 Export PDF
+              </button>
+              <!-- script warning shown in FigureView.initialise() if needed -->
+              <button
+                type="button" style="display: none"
+                class="btn btn-danger btn-sm script_version_warning"
+              >
+                <i class="bi-exclamation-circle"></i>
               </button>
               <button
                 type="button"

--- a/src/index.html
+++ b/src/index.html
@@ -10,10 +10,13 @@
       // These are updated by views.py when serving this page...
       const BASE_OMEROWEB_URL = dev_omeroweb_url;
       const EXPORT_ENABLED = false;
+      const SCRIPT_VERSION = "";
+      const IS_ADMIN = true;
       const WEBINDEX_URL = BASE_OMEROWEB_URL + "webclient/";
       const BASE_WEBFIGURE_URL = BASE_OMEROWEB_URL + "figure/";
       const WEBGATEWAYINDEX = BASE_OMEROWEB_URL + "webgateway/";
       const MAKE_WEBFIGURE_URL = BASE_WEBFIGURE_URL + "make_web_figure/";
+      const UPLOAD_OMERO_SCRIPT_URL = BASE_WEBFIGURE_URL + "upload_omero_script/";
       const ACTIVITIES_JSON_URL = WEBINDEX_URL + "activities_json/";
       const API_BASE_URL_V0 = BASE_OMEROWEB_URL + "api/v0/"
       const STATIC_DIR = "";
@@ -1200,6 +1203,8 @@
       </div>
     </div>
 
+    <load src="html/dialogs/scriptManagerDialog.html" />
+
     <!-- -- END OF MODAL DIALOGS -- -->
 
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -1570,15 +1575,22 @@
                 <i class="bi-exclamation-triangle"></i>
             </a>
 
-            <button
+            <!-- <button
               type="button"
               style="display: none"
               class="btn btn-danger btn-sm"
             >
               <i class="bi-exclamation-triangle"></i>
-            </button>
+            </button> -->
 
             <div class="btn-group">
+              <button
+                title="Wrong script version!"
+                type="button"
+                class="btn btn-danger btn-sm script_version_warning"
+              >
+                <i class="bi-exclamation-circle"></i>
+              </button>
               <!-- button enabled if EXPORT_ENABLED is true -->
               <button
                 type="button"

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -26,6 +26,7 @@
         hideModals,
         hideModal,
         updateRoiIds} from "./util";
+    const RELEASE_VERSION = import.meta.env.VITE_VERSION;
 
     // This extends Backbone to support keyboardEvents
     backboneMousetrap(_, Backbone, Mousetrap);
@@ -92,6 +93,14 @@
             // enable export (script is available)
             if (EXPORT_ENABLED) {
                 $("button.export_pdf").removeAttr("disabled");
+                // check script version
+                if (SCRIPT_VERSION != RELEASE_VERSION) {
+                    $(".script_version_warning").show()
+                    .attr("title", "Script Version Warning");
+                }
+            } else if (IS_ADMIN) {
+                $(".script_version_warning").show()
+                    .attr("title", "Script Not Upload to OMERO.server");
             }
 
             // respond to zoom changes
@@ -225,7 +234,6 @@
         },
 
         script_version_warning: function(event) {
-            const RELEASE_VERSION = import.meta.env.VITE_VERSION;
             document.getElementById("figure_app_version").innerHTML = RELEASE_VERSION;
             let script_version = SCRIPT_VERSION.length > 0 ? SCRIPT_VERSION : "unknown";
             document.getElementById("export_script_version").innerHTML = script_version;

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -234,22 +234,44 @@
         },
 
         script_version_warning: function(event) {
+            // Show the script manager (warning/upload) dialog
             document.getElementById("figure_app_version").innerHTML = RELEASE_VERSION;
             let script_version = SCRIPT_VERSION.length > 0 ? SCRIPT_VERSION : "unknown";
             document.getElementById("export_script_version").innerHTML = script_version;
 
+            if (EXPORT_ENABLED) {
+                $(".script_version_mismatch").show();
+                $(".script_missing").hide();
+            } else {
+                $(".script_version_mismatch").hide();
+                $(".script_missing").show();
+            }
             if (IS_ADMIN) {
                 $("#admin_script_message").show();
             } else {
                 $("#non_admin_script_message").show();
             }
+            $("#script_upload_message").hide();
             showModal("scriptManagerDialog");
         },
 
         upload_omero_script: function(event) {
+            let $btn = $(".upload_omero_script");
+            let $spinner = $(".spinner", $btn);
+            $btn.attr("disabled", "disabled");
+            $spinner.show();
             $.post(UPLOAD_OMERO_SCRIPT_URL)
              .done(function( data ) {
-                alert(data);
+                console.log("rsp", data);
+                $btn.removeAttr("disabled");
+                $spinner.hide();
+                let message = data.Error ? "Error: " + data.Error : data.Message;
+                if (data.script_id) {
+                    // success! Hide warning button
+                    $(".script_version_warning").hide();
+                    message += ". Script ID: " + data.script_id;
+                }
+                $("#script_upload_message").text(message).show();
             });
         },
 

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -100,7 +100,7 @@
                 }
             } else if (IS_ADMIN) {
                 $(".script_version_warning").show()
-                    .attr("title", "Script Not Upload to OMERO.server");
+                    .attr("title", "Script missing! Click to Upload...");
             }
 
             // respond to zoom changes

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -117,6 +117,8 @@
 
         events: {
             "click .export_pdf": "export_pdf",
+            "click .script_version_warning": "script_version_warning",
+            "click .upload_omero_script": "upload_omero_script",
             "click .export_options li": "export_options",
             "click .add_panel": "addPanel",
             "click .delete_panel": "deleteSelectedPanels",
@@ -220,6 +222,27 @@
 
             // clear file list (will be re-fetched when needed)
             this.figureFiles.reset();
+        },
+
+        script_version_warning: function(event) {
+            const RELEASE_VERSION = import.meta.env.VITE_VERSION;
+            document.getElementById("figure_app_version").innerHTML = RELEASE_VERSION;
+            let script_version = SCRIPT_VERSION.length > 0 ? SCRIPT_VERSION : "unknown";
+            document.getElementById("export_script_version").innerHTML = script_version;
+
+            if (IS_ADMIN) {
+                $("#admin_script_message").show();
+            } else {
+                $("#non_admin_script_message").show();
+            }
+            showModal("scriptManagerDialog");
+        },
+
+        upload_omero_script: function(event) {
+            $.post(UPLOAD_OMERO_SCRIPT_URL)
+             .done(function( data ) {
+                alert(data);
+            });
         },
 
         // Heavy lifting of PDF generation handled by OMERO.script...

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -101,6 +101,9 @@
             } else if (IS_ADMIN) {
                 $(".script_version_warning").show()
                     .attr("title", "Script missing! Click to Upload...");
+            } else {
+                $(".script_version_warning").show()
+                    .attr("title", "Export script not installed. Contact your OMERO administrator.");
             }
 
             // respond to zoom changes

--- a/src/js/views/figure_view.js
+++ b/src/js/views/figure_view.js
@@ -267,8 +267,9 @@
                 $spinner.hide();
                 let message = data.Error ? "Error: " + data.Error : data.Message;
                 if (data.script_id) {
-                    // success! Hide warning button
+                    // success! Hide warning button and enable export.
                     $(".script_version_warning").hide();
+                    $(".export_pdf").removeAttr("disabled");
                     message += ". Script ID: " + data.script_id;
                 }
                 $("#script_upload_message").text(message).show();

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
+import injectHTML from 'vite-plugin-html-inject';
+
 const path = require('path')
 
 export default {
   root: path.resolve(__dirname, 'src'),
+  plugins: [injectHTML()],
   resolve: {
     alias: {
       '~bootstrap': path.resolve(__dirname, 'node_modules/bootstrap'),


### PR DESCRIPTION
This addresses a couple of issues:
 - Fixes #556 - Users get incorrect or failed figure export if using an old version of the script - Easily done if the script is not updated when OMERO.figure is upgraded. 
 - Also makes it possible for Admins to use the OMERO.figure app itself to upload the current version of the script.

With this PR, the web app loads the `Figure_To_Pdf.py` script from within the Django app (using relative path from `views.py` -> `../scripts/omero/Figure_Scripts/Figure_To_Pdf.py` and uploads it to the server using the script service (if the current user is an Admin).

We also add a `FIGURE_VERSION` parameter to the `Figure_To_Pdf.py` script, with the default value being set to the release version of OMERO.figure. This allows the web app to use the script service to query the script parameters and get the `FIGURE_VERSION` from the script. Scripts from before this PR won't have this parameter, so the version will be "unknown". If the `FIGURE_VERSION` from the script doesn't match the version of the app, all users will see a warning, and if user is an Admin, they can update the script with a single button click!

For regular users:
 - If no export script is on the server, Export PDF button is disabled (no change)
 - If an out-of-date version of the script is on the server, they will see a warning button that opens a dialog to show mismatching version numbers, and a message "Admin needs to fix this".

For admin users:
 - If no export script is on the server, show a warning button to open script upload dialog. `Upload Script` button.
 - If an out-of-date version of the script is on the server, they will see a warning button that opens a dialog to show mismatching version numbers, and an `Update Script` button.

Testing info, see below...

![Screenshot 2025-01-30 at 13 23 41](https://github.com/user-attachments/assets/2eef5205-c8cf-4d49-a5e8-e63d816faae5)

![Screenshot 2025-01-30 at 13 27 23](https://github.com/user-attachments/assets/bc7267d2-083d-4506-b0c3-da7ee0c5d6bd)

![Screenshot 2025-01-30 at 13 28 21](https://github.com/user-attachments/assets/a207117d-9ad5-4320-a5fa-78f45f8289f5)


To test:
 - Start with NO script on the server. Use cli `$ omero script list` to get the ID of the `Figure_To_Pdf.py` and then delete it with `$ omero delete OriginalFile:ID`.
 - Login to OMERO.figure as an Admin. `Export Pdf` button will be disabled as before. You should now see a warning button (top right) with appropriate tooltip. Click the button to show dialog (first screenshot above). Click "Upload Script" to upload to the server. Should see success message and `Export Pdf` button will be enabled etc.
 - Go to webclient and use the script menu to upload an OLD version of the `Figure_To_Pdf.py` (e.g. from last release). Make sure it is in the correct path `omero/figure_scripts/Figure_To_Pdf.py` so that is replaces the existing script.
 - Login to OMERO.figure page as regular user. Now you should see the script warning with version mismatch. Dialog gives more info, including a "contact Admin" message. (2nd screenshot) 
 - Login to OMERO.figure as an Admin. You'll get the warning and the dialog should allow you to Upgrade the script (3rd screenshot)

NB: for devs: this PR adds usage of https://www.npmjs.com/package/vite-plugin-html-inject so we can include html files into index.html. This will allow us to move all the dialogs into separate html files (as I've done for the new dialog here).