### PR TITLE
fix word wrap of image names

### DIFF
--- a/src/templates/info_panel.template.html
+++ b/src/templates/info_panel.template.html
@@ -1,5 +1,5 @@
 
-    <p><% print(_.escape(name)) %></p>
+    <p style="word-break: break-word"><% print(_.escape(name)) %></p>
     <div class="clearfix"></div>
 
     <table class="table" style="margin-bottom: 0;">


### PR DESCRIPTION
2nd Try
added word-break style so longer Image names get properly wrapped and stay readable