### PR TITLE
enable dragging and resizing shapes without having to select it multi…

### DIFF
--- a/src/js/shape_editor/shape_manager.js
+++ b/src/js/shape_editor/shape_manager.js
@@ -730,7 +730,6 @@ ShapeManager.prototype.notifySelectedShapesChanged =
 ShapeManager.prototype.notifyShapesChanged = function notifyShapesChanged(
   shapes
 ) {
-  this.sortShape(this._shapes);
   this.$el.trigger("change:shape", [shapes]);
 };
 


### PR DESCRIPTION
Hello @will-moore , 

Fix the below behavior when dragging / resizing shapes. It is currently only possible to do 
- `select / drag / deselect`
- `select / resize / deselect`

and nothing else (`select / drag / resize / drag` is currently not possible). The fix now enables that.

Before
![bug](https://github.com/user-attachments/assets/43ece1f1-7cbd-458d-aa55-c68bcbf7acd8)

After
![bugfixed](https://github.com/user-attachments/assets/a26e495b-52db-4c18-b51e-16b1f5866c3f)



