### PR TITLE
Fix Crop dialog scrolling for arbitary angles

### DIFF
--- a/src/css/figure.css
+++ b/src/css/figure.css
@@ -1,5 +1,3 @@
-
-
 /* Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
  All rights reserved.
 
@@ -1124,6 +1122,15 @@
         cursor:  crosshair;
         cursor:  url("../images/crop20.png") 10 10, crosshair;
         z-index: 10;
+    }
+
+    #crop_paper {
+        position: relative !important;
+        overflow: visible !important;
+        top: auto !important;
+        left: auto !important;
+        right: auto !important;
+        bottom: auto !important;
     }
 
     .roiPickMe {


### PR DESCRIPTION
[Description of PR]

Please see https://github.com/ome/omero-figure/blob/master/docs/contributing.md
for a testing checklist.

Fixes #533 

- It seems the issues 533 is already partly solved for angles that are multiples of 90 degrees. 
- However, for random angles like 125 degrees in the attached images, the images are still cut off towards the -ve x-axis and +ve y-axis.
- Also, it means the slider inside the Crop dialog starts after cropping the rotated image in -ve x-axis and +ve y-axis.
- This PR solves cut off issues for rotation of images for random angles. 

<br>

Below are before(cropped) and after(not cropped) images : 

**Before :** 
<br>

<img width="1007" height="674" alt="OMERO figure-Issue533-Before" src="https://github.com/user-attachments/assets/878219a9-8fa9-4152-9d66-fbfac894d7a3" />

**After :** 
<br>
<img width="1001" height="666" alt="OMERO figure-Issue533-After" src="https://github.com/user-attachments/assets/0d75a4d6-769c-4a5d-ba0e-17eeda286194" />
