### PR TITLE
Avoid division by zero and don't save x/y NaN in grid layout

### DIFF
--- a/src/js/models/figure_model.js
+++ b/src/js/models/figure_model.js
@@ -896,7 +896,9 @@
                         new_x = reference_grid[lastRefColumn] -closest_column*(last_panel_width + spacer)
                     }
 					last_column_id++
-                    panel.save({'x':new_x, 'y':y});
+                    if (!isNaN(new_x) && !isNaN(y)) {
+                        panel.save({'x':new_x, 'y':y});
+                    }
                     new_x = new_x + spacer + panel.get('width');
                 }
             }


### PR DESCRIPTION
Fix issue reported at https://github.com/ome/omero-figure/pull/651#discussion_r2631608389

To test:
 - Try various random / invalid / overlapping positions of panels and try to align to grid (e.g. see comment above)
 - The results may not be predictable (which is OK) but at least we avoid dividing by `0` (no Infinity and infinite loops - app becomes unresponsive!) and we also MUST avoid saving `NaN` to `x` or `y`.

cc @Rdornier 