### PR TITLE
Fix ability of export script to be installed and run without reportlab

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -38,8 +38,6 @@ from omero.model.enums import UnitsLength
 
 from io import BytesIO
 
-from reportlab.pdfbase.pdfmetrics import stringWidth
-
 try:
     from PIL import Image, ImageDraw, ImageFont
 except ImportError:
@@ -64,6 +62,7 @@ try:
     from reportlab.platypus import Paragraph
     from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT
     from reportlab.lib.utils import ImageReader
+    from reportlab.pdfbase.pdfmetrics import stringWidth
     reportlab_installed = True
 except ImportError:
     reportlab_installed = False


### PR DESCRIPTION
Fixes a potential bug from the last release:

In the export script, we import `reportlab` in a try/except block so that the script can be installed and run even if reportlab isn't installed on the server.

This is useful since we can't require reportlab as a server dependency, so it must be installed manually (and may be missing).

cc @Rdornier 