### PR TITLE
Remove commit from gist demoUrl to load latest, with livingobjects URLs

### DIFF
--- a/src/js/views/open_local_file_modal.js
+++ b/src/js/views/open_local_file_modal.js
@@ -18,7 +18,7 @@ export const OpenLocalFileModalView = Backbone.View.extend({
         this.app = options.app;
     
         // TEMP? show a default file to open
-        let demoUrl = "https://gist.githubusercontent.com/will-moore/75a7f0de5be0f7b4202d5f0229cadcc9/raw/edf0f16c512942eb9fe347d22707a0fbcf33c917/ngff_images_figure.json";
+        let demoUrl = "https://gist.githubusercontent.com/will-moore/75a7f0de5be0f7b4202d5f0229cadcc9/raw/ngff_images_figure.json";
         $(".figureFileUrl", this.el).val(demoUrl);
         this.enableSubmit();
 


### PR DESCRIPTION
To test the URL, you can use: https://ome.github.io/omero-figure/, do `File > Open` and enter the gist URL from this PR.
All the images should be loading from `livingobjects` (can click on the ome-ngff-validator links in the Info panel).

To test the actual `File > Open` default URL (without entering a URL manually), we'd need to deploy from this branch.
This isn't really needed since in this case since the change is very simple, but...

In future PRs, it would be useful to have netlify deploy the omero-figure app for every open PR.
cc @joshmoore has set this up in the past for various OME repos, so if you could do the same again for omero-figure, that would be great.