### PR TITLE
Enable pre-release rc workflow with bumpversion and publish to pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,6 +13,7 @@ optional_value = prod
 first_value = dev
 values = 
 	dev
+	rc
 	prod
 
 [bumpversion:part:build]

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -15,7 +15,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          # Allow either 1.2.3rc1 or v1.2.3rc1 tags.
+          # Allow either 1.2.3.rc1 or v1.2.3.rc1 tags.
           TAG_NO_V="${TAG#v}"
           PKG_VERSION="$(python -c \"import omero_figure.utils as u; print(u.__version__)\")"
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -11,6 +11,36 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Validate tag matches package version
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Allow either 1.2.3rc1 or v1.2.3rc1 tags.
+          TAG_NO_V="${TAG#v}"
+          PKG_VERSION="$(python -c \"import omero_figure.utils as u; print(u.__version__)\")"
+
+          echo "Tag: ${TAG}"
+          echo "Package version: ${PKG_VERSION}"
+
+          # Compare normalized PEP 440 versions so 1.2.3.rc1 and 1.2.3rc1 are equivalent.
+          python - <<'PY'
+          import os
+          import sys
+
+          from packaging.version import Version
+
+          tag = os.environ["TAG_NO_V"]
+          pkg = os.environ["PKG_VERSION"]
+          tag_v = Version(tag)
+          pkg_v = Version(pkg)
+
+          if tag_v != pkg_v:
+              print(f"ERROR: Tag ({tag}) does not match package version ({pkg}).")
+              print(f"Normalized tag={tag_v}, package={pkg_v}")
+              sys.exit(1)
+
+          print(f"Validated normalized version match: {tag_v}")
+          PY
       - name: Build a binary wheel and a source tarball
         run: |
           python -mpip install build
@@ -22,6 +52,14 @@ jobs:
           password: ${{ secrets.PYPI_PASSWORD }}
       - name: Create a GitHub release
         if: startsWith(github.ref, 'refs/tags')
-        run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}"
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG_NO_V="${TAG#v}"
+          # Mark a/b/rc tags as prereleases.
+          if echo "${TAG_NO_V}" | grep -Eq '[0-9](\.?)(a|b|rc)[0-9]+$'; then
+            gh release create --generate-notes --prerelease "${TAG}"
+          else
+            gh release create --generate-notes "${TAG}"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -260,28 +260,24 @@ To tag a stable release from RC run::
 
     $ bumpversion release    # e.g. 8.0.1.rc1 -> 8.0.1
 
+To create a stable release directly from ``.dev0`` (without RC), set an explicit version and tag it, for example::
+
+    $ bumpversion --new-version 8.0.1 release
+
+Remember to ``git push`` all commits and tags.
+
 To switch back to a development version run::
 
     $ bumpversion --no-tag [major|minor|patch]
+
+specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
+
 
 PyPI publishing notes:
 
 * Publishing is triggered by Git tags in the GitHub action.
 * The published package version comes from ``omero_figure/utils.py`` (not from tag text alone).
 * The workflow validates that the tag version and package version match before publishing.
-* Tag formats ``8.0.1rc1`` and ``v8.0.1rc1`` are both accepted.
-
-To create a stable release directly from ``.dev0`` (without RC), set an explicit version and tag it, for example::
-
-    $ bumpversion --new-version 8.0.1 release
-
-Previous flow (kept for reference) was:
-
-    $ bumpversion release
-
-specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
-
-Remember to ``git push`` all commits and tags.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -249,15 +249,35 @@ Release process
 ---------------
 
 This repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.
-To tag a release run::
+To create a release-candidate (RC) from a development version run::
 
-    $ bumpversion release
+    $ bumpversion release    # e.g. 8.0.1.dev0 -> 8.0.1.rc0
+    $ bumpversion build      # e.g. 8.0.1.rc0 -> 8.0.1.rc1
 
-This will remove the ``.dev0`` suffix from the current version, commit, and tag the release.
+This creates commits and tags by default.
+
+To tag a stable release from RC run::
+
+    $ bumpversion release    # e.g. 8.0.1.rc1 -> 8.0.1
 
 To switch back to a development version run::
 
     $ bumpversion --no-tag [major|minor|patch]
+
+PyPI publishing notes:
+
+* Publishing is triggered by Git tags in the GitHub action.
+* The published package version comes from ``omero_figure/utils.py`` (not from tag text alone).
+* The workflow validates that the tag version and package version match before publishing.
+* Tag formats ``8.0.1rc1`` and ``v8.0.1rc1`` are both accepted.
+
+To create a stable release directly from ``.dev0`` (without RC), set an explicit version and tag it, for example::
+
+    $ bumpversion --new-version 8.0.1 release
+
+Previous flow (kept for reference) was:
+
+    $ bumpversion release
 
 specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
 

--- a/README.rst
+++ b/README.rst
@@ -264,14 +264,13 @@ To create a stable release directly from ``.dev0`` (without RC), set an explicit
 
     $ bumpversion --new-version 8.0.1 release
 
-Remember to ``git push`` all commits and tags.
-
 To switch back to a development version run::
 
     $ bumpversion --no-tag [major|minor|patch]
 
 specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
 
+Remember to ``git push`` all commits and tags.
 
 PyPI publishing notes:
 


### PR DESCRIPTION
This PR adds pre-release support to bumpversion workflow to prevent the accidental publishing of rc versions as full releases.

Issue: Running:

```
bumpversion --new-version 8.0.0rc1 release
```
actually set the `__version__ = "8.0.0"` because "bumpversion config in .bumpversion.cfg:1 only models dev/prod, not rc. So your current automated bump flow does not support release candidates cleanly" (copilot).

See the resulting commit at https://github.com/ome/omero-figure/commit/3e44ff98c4f581f706313f45aa420e2231e06b92

Also, the `publish_pypi.yml` workflow didn't check that the gh tag and the `__version__` were the same.

All the changes in this PR are from github copilot. 

See `README` for details of how to do full release, specifying version (no change) and rc release.

To test:
 - checkout this branch
 - Run `bumpversion release` and check that the `__version__` in the commit
 - Then delete your local tag and reset to previous commit etc (don't push!)

When I try this, I see e.g. utils.py

```
-__version__ = "8.0.1.dev0"
+__version__ = "8.0.1.rc0"
```
And the Tag created is `tag: v8.0.1.rc0`.


<details><summary>Full github copilot discussion</summary>

Me: "I want to be able to create a pre-release tag that will publish a pre-release version to pypi. When I created a tag 8.0.0rc1 this published a full release 8.0.0 to pypi which is NOT what I want. Do I need to change the github workflow here, or use a different pre-release tag naming?"

Optimizing tool selection...

I’ll inspect the publish workflow and the package versioning logic to see why a tag like 8.0.0rc1 ended up as 8.0.0 on PyPI, then I’ll tell you whether the fix belongs in tag naming, workflow logic, or both.

I found the workflow always publishes on any tag; next I’m checking where the package version is sourced, since PyPI uses package metadata version (not tag text) unless you wire it in.

I’ve confirmed the key point: PyPI publication uses the package’s declared version from source, not the Git tag string. I’ll quickly check the release/version tooling config to confirm the intended version bump flow before giving a concrete recommendation.

I’ve isolated the cause and the safest fix path: your workflow publishes any tag, but the actual published version comes from source code version fields, so I’ll give you an exact release rule set plus an optional workflow guard to prevent this happening again.Use both: correct pre-release version in source and a small workflow guard. Tag naming alone is not enough.

What happened:

Your workflow publishes on any tag push in [publish_pypi.yml:1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [publish_pypi.yml:15](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The package version is taken from [setup.py:31](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [setup.py:55](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), which reads [utils.py:22](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
PyPI uses that package metadata version, not the Git tag text. So if source version was 8.0.0, tagging 8.0.0rc1 still publishes 8.0.0.
For pre-releases on PyPI:

Set source version to a PEP 440 pre-release, e.g. 8.0.0rc1 in [utils.py:22](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (and matching script version file if you keep them aligned).
Build and publish from that commit.
Tag should match exactly (e.g. 8.0.0rc1 or v8.0.0rc1 consistently).
Naming is fine as 8.0.0rc1; the key is source version must also be 8.0.0rc1.
Also important:

Your bumpversion config in [.bumpversion.cfg:1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) only models dev/prod, not rc. So your current automated bump flow does not support release candidates cleanly.
Recommended workflow hardening:

Add a step to fail if tag != package version.
Optionally mark GitHub release as prerelease when tag contains a, b, or rc.
If you want, I can patch [publish_pypi.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now to enforce tag/version matching so this can’t accidentally publish a stable version again.


I’ll patch the workflow now to block mismatched tag/version publishes and to auto-mark rc/a/b tags as GitHub pre-releases, so accidental stable PyPI releases are prevented.

Edited
publish_pypi.yml+24-1
I’ve applied the workflow hardening; next I’ll quickly sanity-check for syntax/issues and then summarize exactly how to tag pre-releases going forward.

Checked [publish_pypi.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), no problems found

Implemented in [publish_pypi.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) .

What changed:

Added a tag/version validation step before build and publish.
It now fails the workflow if tag version and package version differ.
It accepts either style:
8.0.0rc1
v8.0.0rc1
GitHub release creation now auto-sets prerelease for tags ending in aN, bN, or rcN.
Why this fixes your issue:

PyPI publishes the version from package metadata (from [setup.py:31](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> [utils.py:22](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), not from tag text.
With the new guard, a tag like 8.0.0rc1 can no longer publish 8.0.0 by mistake.
How to do prereleases now:

Set package version in source to a PEP 440 prerelease such as 8.0.0rc1.
Create tag 8.0.0rc1 (or v8.0.0rc1).
Push tag.
Workflow publishes prerelease package and creates a GitHub prerelease automatically.
Natural next step:

If you want, I can also update [.bumpversion.cfg](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so your bump command supports rc versions directly (instead of only dev/prod).


I’ll update the version bump config next so it can represent release candidates cleanly, and I’ll align the publish check to accept equivalent normalized versions like 8.0.0.rc1 and 8.0.0rc1.

I’m applying two small edits now: one to make tag/version comparison normalization-safe in the workflow, and one to let bumpversion model an rc stage directly.

Completed. I updated both the publish guard and bumpversion configuration.

Changes made:

Updated [publish_pypi.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Tag/package validation now compares normalized PEP 440 versions, so forms like 8.0.0.rc1 and 8.0.0rc1 are treated as equivalent.
GitHub release pre-release detection now also accepts dotted pre-release tags (for example, 8.0.0.rc1) as well as undotted ones.
Updated [.bumpversion.cfg](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added an rc stage to the release progression values:
dev -> rc -> prod
What this gives you now:

You can publish RC builds safely, and the workflow will block mismatched tag vs package versions.
You do not need a different naming convention than before. 8.0.0rc1 is fine.
If your source version is 8.0.0.rc1, that will also validate against a tag 8.0.0rc1.
Recommended release flow:

Set package version to an rc form (for example 8.0.0rc1 or 8.0.0.rc1).
Create matching tag (or v-prefixed matching tag).
Push tag and let the workflow publish.
If you want, I can also add a short Release section in [README.rst](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with exact RC tagging examples so the process is documented for the team.

Me: yes please

I’ll add a short prerelease section to the existing release docs, including exact tag/version examples and the new workflow safety check behavior so the team has a reliable runbook.

Edited
README.rst+24-4
I’ve inserted the release/prerelease runbook; I’ll do a quick validation pass for file issues, then summarize exactly what was added.

Checked [README.rst](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), no problems found

I’m recording one repository note so this release-version behavior is easy to reuse in future tasks.

Created memory file [release-versioning.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added. The release docs now include an explicit prerelease workflow in [README.rst](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

What I added:

RC flow using bump2version:
bumpversion release for dev -> rc
bumpversion build for rc0 -> rc1
Stable-from-RC flow:
bumpversion release for rc -> stable
PyPI notes clarifying:
publish is tag-triggered
published version comes from package version source
workflow now enforces tag/version match
8.0.1rc1 and v8.0.1rc1 are accepted tag styles
Optional direct stable-from-dev note with explicit versioning command.
Everything validates cleanly (no errors reported in [README.rst](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).

</details>