### PR TITLE
Add touch support for clicking on single panel

### DIFF
--- a/src/js/views/raphael-rect.js
+++ b/src/js/views/raphael-rect.js
@@ -204,6 +204,12 @@ const RectView = Backbone.View.extend({
              self.selectShape(e);
         });
 
+        // add touch support for mobile
+        this.element.touchstart(function(e){
+             e.stopImmediatePropagation();
+             self.selectShape(e);
+        });
+
         this.updateShape();  // sync position, selection etc.
 
         // Finally, we need to render when model changes


### PR DESCRIPTION
I realised that OMERO.figure actually looks OK on mobile, but that panels couldn't be selected.

This PR adds "touch" support to Raphael rectangles so you can "touch" a panel and it is selected.

Also pushed to my `master` branch to deploy to https://will-moore.github.io/omero-figure/

On mobile emulator, before and after "touching" a panel to select it. 

<img width="484" height="997" alt="Screenshot 2026-04-17 at 17 04 14" src="https://github.com/user-attachments/assets/9b77a058-cd85-4808-a972-e6a3006f1258" />

<img width="468" height="1003" alt="Screenshot 2026-04-17 at 17 04 31" src="https://github.com/user-attachments/assets/2846d607-11f3-4b3b-ab97-ac147c2d216d" />
