### PR TITLE
Fix PKG_VERSION fix in publish_pypi.yml

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -11,36 +11,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - name: Validate tag matches package version
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          # Allow either 1.2.3.rc1 or v1.2.3.rc1 tags.
-          TAG_NO_V="${TAG#v}"
-          PKG_VERSION=$(python -c "import omero_figure.utils as u; print(u.__version__)")
-
-          echo "Tag: ${TAG}"
-          echo "Package version: ${PKG_VERSION}"
-
-          # Compare normalized PEP 440 versions so 1.2.3.rc1 and 1.2.3rc1 are equivalent.
-          python - <<'PY'
-          import os
-          import sys
-
-          from packaging.version import Version
-
-          tag = os.environ["TAG_NO_V"]
-          pkg = os.environ["PKG_VERSION"]
-          tag_v = Version(tag)
-          pkg_v = Version(pkg)
-
-          if tag_v != pkg_v:
-              print(f"ERROR: Tag ({tag}) does not match package version ({pkg}).")
-              print(f"Normalized tag={tag_v}, package={pkg_v}")
-              sys.exit(1)
-
-          print(f"Validated normalized version match: {tag_v}")
-          PY
       - name: Build a binary wheel and a source tarball
         run: |
           python -mpip install build

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -17,7 +17,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           # Allow either 1.2.3.rc1 or v1.2.3.rc1 tags.
           TAG_NO_V="${TAG#v}"
-          PKG_VERSION="$(python -c \"import omero_figure.utils as u; print(u.__version__)\")"
+          PKG_VERSION=$(python -c "import omero_figure.utils as u; print(u.__version__)")
 
           echo "Tag: ${TAG}"
           echo "Package version: ${PKG_VERSION}"


### PR DESCRIPTION
This aims to fix the error at https://github.com/ome/omero-figure/actions/runs/24660519372/job/72105014376

Running locally, this works:

```
$ PKG_VERSION=$(python -c "import omero_figure.utils as u; print(u.__version__)")
$ echo $PKG_VERSION 
8.0.1.rc0
```