### PR TITLE
Fix static files links for release build

### DIFF
--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -156,14 +156,6 @@ def index(request, file_id=None, conn=None, **kwargs):
 
     # update links to static files
     static_dir = static.static('omero_figure/')
-
-    # The following lines remove the "omero-figure/" which comes from vite config.base
-    # *ONLY* present when built by gh-actions (where it's needed for gh-pages deploy).
-    # So, we need this fix for *release* builds built by gh-actions (NOT when installed from GitHub and built locally).
-    html = html.replace('href="/omero-figure/', 'href="/')
-    html = html.replace('src="/omero-figure/', 'src="/')
-
-    # Now we can update the standalone page to point to the OMERO static dir
     html = html.replace('href="/assets',
                         'href="%sassets' % static_dir)
     html = html.replace('src="/assets',

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -156,6 +156,14 @@ def index(request, file_id=None, conn=None, **kwargs):
 
     # update links to static files
     static_dir = static.static('omero_figure/')
+
+    # The following lines remove the "omero-figure/" which comes from vite config.base
+    # *ONLY* present when built by gh-actions (where it's needed for gh-pages deploy).
+    # So, we need this fix for *release* builds built by gh-actions (NOT when installed from GitHub and built locally).
+    html = html.replace('href="/omero-figure/', 'href="/')
+    html = html.replace('src="/omero-figure/', 'src="/')
+
+    # Now we can update the standalone page to point to the OMERO static dir
     html = html.replace('href="/assets',
                         'href="%sassets' % static_dir)
     html = html.replace('src="/assets',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build --emptyOutDir && ./deploy_build.sh",
-    "ghpages": "vite build --outDir ../gh_pages && ./deploy_ghpages.sh",
+    "ghpages": "vite build --outDir ../gh_pages --base /omero-figure/ && ./deploy_ghpages.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "watch 'npm run build' ./src"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,10 @@ let config = {
 }
 
 // this will be undefined when deployed from netlify, but is used by gh-pages
+// if Unset, we get e.g. src="/assets/index-CQUJWFOE.js"> in index.html. (default behaviour)
+// If set, src="/omero-figure/assets/index-Tjqwbv6v.js"> which is needed for gh-pages deployed to https://ome.github.io/omero-figure/
+// NB: GITHUB_REPOSITORY_OWNER is *also* set when we do a release build via GitHub Actions...
+// ...but this is handled (removed) in views.py when serving the index.html.
 if (process.env.GITHUB_REPOSITORY_OWNER) {
   config.base = "/omero-figure/";
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,13 +27,6 @@ let config = {
   assetsInclude: ["**/*.template.html"],
 }
 
-// this will be undefined when deployed from netlify, but is used by gh-pages
-// if Unset, we get e.g. src="/assets/index-CQUJWFOE.js"> in index.html. (default behaviour)
-// If set, src="/omero-figure/assets/index-Tjqwbv6v.js"> which is needed for gh-pages deployed to https://ome.github.io/omero-figure/
-// NB: GITHUB_REPOSITORY_OWNER is *also* set when we do a release build via GitHub Actions...
-// ...but this is handled (removed) in views.py when serving the index.html.
-if (process.env.GITHUB_REPOSITORY_OWNER) {
-  config.base = "/omero-figure/";
-}
+// NB: config.base is set to "/omero-figure/" in ghpages build (see package.json)
 
 export default defineConfig(config);


### PR DESCRIPTION
Fixes the failure to load static files for the 8.0.1.rc1 release (when deployed on outreach server).
This was the first test of installing a *release* build (different from the local built that is tested by merge-ci).

UPDATE: problem was due to `base` url being set when we build via gh-actions (used for gh-pages deploy) but gh-actions is also used for release build.

Now, we ONLY set `base` url when we specifically build for gh-pages.

I have pushed this branch to my https://github.com/will-moore/omero-figure/tree/master branch so that gh-pages is tested to deploy to https://will-moore.github.io/omero-figure/

To test: gh-pages should still deploy correctly (app works etc) and other deploys work too!