### PR TITLE
Add note about zarr etc requirement for export script with zarr images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,17 +110,19 @@ Now install the script's dependencies:
 
 * Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package.
   This needs to be installed in the virtual environment where the ``OMERO.server`` is installed. Depending on your install, you may need to
-  call ``pip`` with, for example: ``/path/to_server_venv/venv/bin/pip install ...``
+  call ``pip`` with, for example: ``/path/to_server_venv/venv/bin/pip install ...``. The install of `Python Markdown <https://python-markdown.github.io/>`_ is optional
+  but is required to format any figure legends that use Markdown syntax.
 
 ::
 
-    $ pip install reportlab
+    $ pip install reportlab markdown
 
-* Optional: Figure legends can be formatted using Markdown syntax. To see this correctly in the exported PDF info page, we need `Python Markdown <https://python-markdown.github.io/>`_:
+* Optional: If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering OME-Zarr images in the export script.
+  These are `zarr`, `dask` and `fsspec[http]`:
 
 ::
 
-    $ pip install markdown
+    $ pip install zarr dask fsspec[http]
 
 
 Run Figure export locally

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ First install the script's dependencies:
 
     $ pip install reportlab markdown
 
-* Optional: If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering
+* Optional (v8.0.1 release candidate only): If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering
   OME-Zarr images in the export script. These are `zarr`, `dask` and `fsspec[http]`:
 
 ::
@@ -125,8 +125,8 @@ Connect to the OMERO server and upload the script via the CLI. It is important t
 ``/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py`` to the OMERO.server ``path/to/OMERO.server/lib/scripts/omero/figure_scripts``. Then restart the OMERO.server.
 
 
-Run Figure export locally
--------------------------
+Run Figure export locally (v8.0.1 release candidate only)
+---------------------------------------------------------
 
 If your figure contains only OME-Zarr images (no images from OMERO), then
 the export script can be run locally to convert a figure JSON file to PDF or TIFF.

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,25 @@ This section assumes that an OMERO.server is already installed.
 Figures can be exported as PDF or TIFF files using a script that runs on the OMERO.server. This script needs to be uploaded to the OMERO.server and its dependencies
 installed in the OMERO.server virtual environment.
 
+First install the script's dependencies:
+
+* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package.
+  This needs to be installed in the virtual environment where the ``OMERO.server`` is installed. Depending on your install, you may need to
+  call ``pip`` with, for example: ``/path/to_server_venv/venv/bin/pip install ...``. The install of `Python Markdown <https://python-markdown.github.io/>`_ is optional
+  but is required to format any figure legends that use Markdown syntax.
+
+::
+
+    $ pip install reportlab markdown
+
+* Optional: If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering
+  OME-Zarr images in the export script. These are `zarr`, `dask` and `fsspec[http]`:
+
+::
+
+    $ pip install zarr dask fsspec[http]
+
+
 The script can be uploaded using various workflows, all of which require you to have the correct admin privileges.
 
 *Option 1*: Log in to the webclient as an Admin and open the OMERO.figure app. If the OMERO script is not found or is not up to date, you will
@@ -104,25 +123,6 @@ Connect to the OMERO server and upload the script via the CLI. It is important t
 
 *Option 3*: Alternatively, before starting the OMERO.server, copy the script from the figure install
 ``/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py`` to the OMERO.server ``path/to/OMERO.server/lib/scripts/omero/figure_scripts``. Then restart the OMERO.server.
-
-Now install the script's dependencies:
-
-
-* Install `reportlab <https://bitbucket.org/rptlab/reportlab>`_ PDF python package.
-  This needs to be installed in the virtual environment where the ``OMERO.server`` is installed. Depending on your install, you may need to
-  call ``pip`` with, for example: ``/path/to_server_venv/venv/bin/pip install ...``. The install of `Python Markdown <https://python-markdown.github.io/>`_ is optional
-  but is required to format any figure legends that use Markdown syntax.
-
-::
-
-    $ pip install reportlab markdown
-
-* Optional: If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering OME-Zarr images in the export script.
-  These are `zarr`, `dask` and `fsspec[http]`:
-
-::
-
-    $ pip install zarr dask fsspec[http]
 
 
 Run Figure export locally


### PR DESCRIPTION
Document need for export script to install zarr if figure has zarr images.

Currently script fails to import zarr, so will error if it contains zarr images (see below).

I guess we could have it silently skip OME-zarr images if `zarr` import fails?

```
Traceback (most recent call last):
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 3562, in <module>
    handle_main()
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 3506, in handle_main
    run_script()
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 3485, in run_script
    file_annotation = export_figure(conn, script_params)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 3437, in export_figure
    return fig_export.build_figure()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 1257, in build_figure
    self.add_panels_to_page(panels_json, page)
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 2761, in add_panels_to_page
    pil_img = self.draw_panel(panel, page, i)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 2580, in draw_panel
    pil_img = self.get_panel_image(panel, orig_name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 2492, in get_panel_image
    scale, pil_img = self.render_zarr_to_pil(panel)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/omero-x/omero/tmp/omero_omero-x/50918/processufqayf2_.dir/./script", line 2328, in render_zarr_to_pil
    import zarr
ModuleNotFoundError: No module named 'zarr'
```

cc @pwalczysko 