### PR TITLE
app handles ?image=1 without needing /new?image=1

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -90,8 +90,11 @@ var FigureRouter = Backbone.Router.extend({
 
   index: function () {
     console.log("index");
+    var cb = () => {
+      showModal("welcomeModal");
+    };
     // Check for ?file=http://...json
-    // TODO: do we ONLY want to do this on index?
+    // OR ?image=1&image=2 (also handled for /new?image=1&image=2 below)
     if (window.location.search.length > 1) {
       const searchParams = new URLSearchParams(window.location.search.substring(1));
       if (searchParams.has("file")) {
@@ -99,14 +102,13 @@ var FigureRouter = Backbone.Router.extend({
         var cb = function () {
           figureModel.load_from_url(file);
         };
-        figureModel.checkSaveAndClear(cb);
-        return;
+      } else if (searchParams.has("image")) {
+        var cb = function () {
+          figureModel.addImages(searchParams.getAll("image"));
+        };
       }
     }
     hideModals();
-    var cb = () => {
-      showModal("welcomeModal");
-    };
     figureModel.checkSaveAndClear(cb);
   },
 


### PR DESCRIPTION
This supports `?image=1&image=2` at the base app url instead of just at /new.

Currently, this doesn't open the image
https://ome.github.io/omero-figure/?image=https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr

but this (with `/new` does): https://ome.github.io/omero-figure/new?image=https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr

This is hard to remember (I'd assumed the first would work). 
This PR enables the former. PR is deployed and can be tested with:
https://will-moore.github.io/omero-figure/?image=https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr&image=https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846151.zarr/0

(should open both images)
