### PR TITLE
colorbar lut background fix

### DIFF
--- a/src/js/views/panel_view.js
+++ b/src/js/views/panel_view.js
@@ -417,6 +417,11 @@
                 lut_url = await FigureLutPicker.loadLuts();  // Ensure lut url and list are loaded
                 lutBgPos = FigureLutPicker.getLutBackgroundPosition(color);
                 lut_url = FigureLutPicker.getLutPng(color);
+                if (lut_url) {
+                    lut_url = 'url(' + lut_url + ')';
+                } else {
+                    lut_url = 'var(--lutPng)';
+                }
             }
             var inverted_pos = {  // convenience variable for the colorbar template.
                 "left": "right",

--- a/src/templates/colorbar.template.html
+++ b/src/templates/colorbar.template.html
@@ -5,7 +5,7 @@
 
             <div class="colorbar_bg "
                 style="height: <%= thickness + 1 %>px;
-                        background-image: <%= isLUT ? 'url(' + lut_url + ')' : 'linear-gradient(to left, #' + color + ', black)' %>;
+                        background-image: <%= isLUT ? lut_url : 'linear-gradient(to left, #' + color + ', black)' %>;
                         <%= isLUT ? 'background-position: ' + lutBgPos : '' %>;
                         <%= reverseIntensity ? 'transform: scaleX(-1);' : '' %>;">
             </div>


### PR DESCRIPTION
Fixes the display of LUT for colorbar when deployed from OMERO.web.

To test:

 - Add a colorbar and set channel to LUT when deployed from OMERO
 - colorbar background should be rendered correctly as LUT