### PR TITLE
Fix parentheses in zoom level for loop for export script

### DIFF
--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2165,8 +2165,8 @@ class FigureExport(object):
         zm = 0
         max_plane = max_sizes[0] * max_sizes[1]
         while (zm < max_level and
-               zm_levels[zm] * width > max_width or
-               zm_levels[zm] * width * zm_levels[zm] * height > max_plane):
+               (zm_levels[zm] * width > max_width or
+                zm_levels[zm] * width * zm_levels[zm] * height > max_plane)):
             zm = zm + 1
 
         level = max_level - zm


### PR DESCRIPTION
Fixes #604 and #699.

The applies the fix identified in both of those issues.

To test, create a big image with limited resolutions, e.g.

`pyramid&sizeX=20000&sizeY=20000&resolutions=3.fake`

Import this image into OMERO and add to a Figure.
See https://merge-ci.openmicroscopy.org/web/webclient/?show=image-2215 
Try to export the Figure. Without this PR, you will see the`KeyError` reported in issues above. 

With this PR, the Figure should export as normal
