### PR TITLE
Readme remove rc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ First install the script's dependencies:
 
     $ pip install reportlab markdown
 
-* Optional (v8.0.1 release candidate only): If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering
+* Optional (v8.0.2 and later): If your figure contains OME-Zarr images, you will also need to install the dependencies for rendering
   OME-Zarr images in the export script. These are `zarr`, `dask` and `fsspec[http]`:
 
 ::
@@ -125,28 +125,27 @@ Connect to the OMERO server and upload the script via the CLI. It is important t
 ``/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py`` to the OMERO.server ``path/to/OMERO.server/lib/scripts/omero/figure_scripts``. Then restart the OMERO.server.
 
 
-Run Figure export locally (v8.0.1 release candidate only)
----------------------------------------------------------
+Run Figure export locally
+-------------------------
 
 If your figure contains only OME-Zarr images (no images from OMERO), then
 the export script can be run locally to convert a figure JSON file to PDF or TIFF.
-NB: the OME-Zarr URLs must be accessible from the machine where the export script is run.
+NB: the OME-Zarr URLs must be publicly accessible from the machine where the export script is run.
 NB: channel LUTs are not currently supported when rendering OME-Zarr images for PDF or TIFFs.
 Any LUTs will be rendered with white color.
 
 Download the figure JSON (File > Save, in the standalone app) then install the export script.
-Here, we create a new conda environment and install the export script.
-NB: We use the ``--pre`` flag to allow installation of the pre-release version of OMERO.figure:
+Here, we create a new conda environment and install the export script:
 
 ::
 
     $ conda create --name figure_export python=3.12
     $ conda activate figure_export
-    $ pip install --pre "omero-figure[export]"
+    $ pip install "omero-figure[export]"
 
 To export the figure as PDF or TIFF, run the script with the path to the figure JSON and the output file path as arguments:
 Use the ``.pdf`` extension for PDF export and ``.tiff`` for TIFF export. This example exports the
-downloaded `figure_json/my_figure.json` to `my_figure.pdf` in the current directory:
+downloaded ``figure_json/my_figure.json`` to ``my_figure.pdf`` in the current directory:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ Run Figure export locally
 
 If your figure contains only OME-Zarr images (no images from OMERO), then
 the export script can be run locally to convert a figure JSON file to PDF or TIFF.
-NB: the OME-Zarr URLs must be publicly accessible from the machine where the export script is run.
+NB: the OME-Zarr URLs must be publicly accessible. Also, you need to be able to access the URLs from the machine where the export script is run.
 NB: channel LUTs are not currently supported when rendering OME-Zarr images for PDF or TIFFs.
 Any LUTs will be rendered with white color.
 

--- a/README.rst
+++ b/README.rst
@@ -288,4 +288,4 @@ OMERO.figure is released under the AGPL.
 Copyright
 ---------
 
-2016-2024, The Open Microscopy Environment
+2016-2026, The Open Microscopy Environment


### PR DESCRIPTION
The removes references to "pre" and "rc" in README, ahead of the release of 8.0.2

To test: readme at https://github.com/will-moore/omero-figure/tree/readme_remove_rc
