### PR TITLE
If big image region is too big, don't try to render

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,13 @@ Optional: To change the maximum active channel count from the default of 10:
 
     $ omero config set omero.figure.max_active_channels 15  
 
+Optional: Big images, where the panel viewport at lowest pyramid resolution exceeds the "big image" threshold
+(approx 3000 x 3000 pixels) are excluded from the exported figures.
+To set a different threshold, e.g. 5000 x 5000 pixels, you can do:
+
+::
+
+    $ omero config set omero.figure.max_panel_pixels 25000000
 
 Now restart OMERO.web as normal.
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1059,6 +1059,11 @@ class FigureExport(object):
 
         self.conn = conn
         self.script_params = script_params
+        self.max_panel_pixels = script_params.get("Max_Panel_Pixels")
+        if self.max_panel_pixels is None:
+            if conn is not None:
+                max_plane_size = self.conn.getMaxPlaneSize()
+                self.max_panel_pixels = max_plane_size[0] * max_plane_size[1]
         self.export_images = export_images
         self.errors = []
         # For standalone script, we may have relative or absolute output path
@@ -2237,21 +2242,19 @@ class FigureExport(object):
             size_y = int(size_y * scale)
 
             # check if region is larger than max plane size...
-            max_sizes = self.conn.getMaxPlaneSize()
-            if width * height > max_sizes[0] * max_sizes[1]:
+            if width * height > self.max_panel_pixels:
                 self.errors.append(
                     f"Failed to render image {image.name} (ID: {image.id}):" +
                     " Smallest pyramid resolution is too large to render:" +
-                    f" {width} x {height} > {max_sizes[0]} x {max_sizes[1]}")
+                    f" {width} x {height} > {self.max_panel_pixels}")
                 # return a placeholder PIL Image with "failed to render" text
                 ph_width = 400
                 ph_height = int(ph_width * (height / width))
-                font = get_font(30)
                 pil_img = Image.new("RGBA", (ph_width, ph_height),
                                     (221, 221, 221, 255))
                 draw = ImageDraw.Draw(pil_img)
                 draw.text((10, 10), "Failed to render",
-                          fill=(255, 0, 0, 255), font=font)
+                          fill=(255, 0, 0, 255), font=get_font(30))
                 return pil_img
 
             try:
@@ -3469,6 +3472,10 @@ def run_script():
 
         scripts.String("Figure_URI",
                        description="URL to the Figure"),
+
+        scripts.Long("Max_Panel_Pixels",
+                     # default limit is conn.getMaxPlaneSize()
+                     description="Don't render panels with image-regions exceeding this limit"),
 
         # This allows clients to query the script version
         # by listing script params and getting default value

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1059,6 +1059,7 @@ class FigureExport(object):
         self.conn = conn
         self.script_params = script_params
         self.export_images = export_images
+        self.errors = []
         # For standalone script, we may have relative or absolute output path
         self.output_path_name = script_params.get("outputPathName")
 
@@ -2237,9 +2238,15 @@ class FigureExport(object):
             # check if region is larger than max plane size...
             max_sizes = self.conn.getMaxPlaneSize()
             if width * height > max_sizes[0] * max_sizes[1]:
-                print("Region is too large to render: %d x %d > %d x %d" %
-                      (width, height, max_sizes[0], max_sizes[1]))
-                return None
+                self.errors.append(
+                    f"Failed to render image {image.name} (ID: {image.id}):" +
+                    f" Smallest pyramid resolution is too large to render:" +
+                    f" {width} x {height} > {max_sizes[0]} x {max_sizes[1]}")
+                # return a placeholder PIL Image with "failed to render" message 
+                pil_img = Image.new("RGBA", (width//10, height//10), (221, 221, 221, 255))
+                draw = ImageDraw.Draw(pil_img)
+                draw.text((10, 10), "Failed to render", fill=(255, 0, 0, 255))
+                return pil_img
 
             try:
                 self.apply_rdefs(image, panel)
@@ -2666,14 +2673,22 @@ class FigureExport(object):
         img_ids = set()
         styles = getSampleStyleSheet()
         style_n = styles['Normal']
+        style_error = styles['Heading3'].clone("error")
+        # error should be red
+        style_error.textColor = "#ff0000"
         style_h = styles['Heading1']
         style_h3 = styles['Heading3']
 
         scalebars = []
         self.margin = min(self.page_width, self.page_height) / 9.0
 
-        # Start adding at the top, update page_y as we add paragraphs
+        # First add any error messages...
         page_y = page_height - self.margin
+        print("ERRORS", self.errors)
+        for msg in self.errors:
+            page_y = self.add_para_with_thumb("Error: " + msg, page_y, style=style_error)
+
+        # Start adding at the top, update page_y as we add paragraphs
         page_y = self.add_para_with_thumb(figure_name, page_y, style=style_h)
 
         if "Figure_URI" in script_params:

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -2234,6 +2234,13 @@ class FigureExport(object):
             size_x = int(size_x * scale)
             size_y = int(size_y * scale)
 
+            # check if region is larger than max plane size...
+            max_sizes = self.conn.getMaxPlaneSize()
+            if width * height > max_sizes[0] * max_sizes[1]:
+                print("Region is too large to render: %d x %d > %d x %d" %
+                      (width, height, max_sizes[0], max_sizes[1]))
+                return None
+
             try:
                 self.apply_rdefs(image, panel)
                 jpeg_data = image.renderJpegRegion(z, t, x, y, width, height,
@@ -2578,6 +2585,8 @@ class FigureExport(object):
             orig_name = os.path.join(
                 self.zip_folder_name, ORIGINAL_DIR, img_name)
         pil_img = self.get_panel_image(panel, orig_name)
+        if pil_img is None:
+            return
 
         # for PDF export, we might have a target dpi
         dpi = panel.get('min_export_dpi', None)
@@ -2764,7 +2773,8 @@ class FigureExport(object):
             self.add_rois(panel, page)  # This does nothing for TIFF export
 
             # Finally, add scale bar and labels to the page
-            self.draw_scalebar(panel, pil_img.size[0], page)
+            if pil_img is not None:
+                self.draw_scalebar(panel, pil_img.size[0], page)
             self.draw_labels(panel, page)
             self.draw_colorbar(panel, page)
 

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -3475,7 +3475,8 @@ def run_script():
 
         scripts.Long("Max_Panel_Pixels",
                      # default limit is conn.getMaxPlaneSize()
-                     description="Don't render panels with image-regions exceeding this limit"),
+                     description=("Don't render panels with image-regions "
+                                  "exceeding this limit")),
 
         # This allows clients to query the script version
         # by listing script params and getting default value

--- a/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -124,6 +124,14 @@ if omero_installed:
             'microns': to_microns.getValue()
         }
 
+if omero_installed:
+    from omero.gateway import THISPATH
+    FONTPATH = os.path.join(THISPATH, "pilfonts")
+else:
+    # get location of this script... /pilfonts
+    this_path = os.path.dirname(os.path.abspath(__file__))
+    FONTPATH = os.path.join(this_path, "pilfonts")
+
 
 def scale_to_export_dpi(pixels):
     """
@@ -151,6 +159,27 @@ def compress(target, base):
                 zip_file.write(fullpath, archive_name)
     finally:
         zip_file.close()
+
+
+def get_font(fontsize, bold=False, italics=False):
+    """ Try to load font from known location in OMERO or local """
+    font_name = "FreeSans.ttf"
+    if bold and italics:
+        font_name = "FreeSansBoldOblique.ttf"
+    elif bold:
+        font_name = "FreeSansBold.ttf"
+    elif italics:
+        font_name = "FreeSansOblique.ttf"
+    path_to_font = os.path.join(FONTPATH, font_name)
+    try:
+        font = ImageFont.truetype(path_to_font, fontsize)
+    except Exception:
+        try:
+            font_path = os.path.join(FONTPATH, "B24.pil")
+            font = ImageFont.load(font_path)
+        except Exception:
+            font = ImageFont.load_default()
+    return font
 
 
 class Bounds(object):
@@ -668,35 +697,7 @@ class ShapeToPilExport(ShapeExport):
         self.scale = pil_img.size[0] / crop['width']
         self.draw = ImageDraw.Draw(pil_img)
 
-        if omero_installed:
-            from omero.gateway import THISPATH
-            self.FONTPATH = os.path.join(THISPATH, "pilfonts")
-        else:
-            # get location of this script... /pilfonts
-            this_path = os.path.dirname(os.path.abspath(__file__))
-            self.FONTPATH = os.path.join(this_path, "pilfonts")
-
         super(ShapeToPilExport, self).__init__(panel)
-
-    def get_font(self, fontsize, bold=False, italics=False):
-        """ Try to load font from known location in OMERO or local """
-        font_name = "FreeSans.ttf"
-        if bold and italics:
-            font_name = "FreeSansBoldOblique.ttf"
-        elif bold:
-            font_name = "FreeSansBold.ttf"
-        elif italics:
-            font_name = "FreeSansOblique.ttf"
-        path_to_font = os.path.join(self.FONTPATH, font_name)
-        try:
-            font = ImageFont.truetype(path_to_font, fontsize)
-        except Exception:
-            try:
-                font_path = os.path.join(self.FONTPATH, "B24.pil")
-                font = ImageFont.load(font_path)
-            except Exception:
-                font = ImageFont.load_default()
-        return font
 
     def get_panel_coords(self, shape_x, shape_y):
         """
@@ -752,7 +753,7 @@ class ShapeToPilExport(ShapeExport):
         r, g, b, a = self.get_rgba_int(shape['strokeColor'])
         # bump up alpha a bit to make text more readable
         rgba = (r, g, b, int(128 + a / 2))
-        font = self.get_font(size)
+        font = get_font(size)
         box = font.getbbox(text)
         width = box[2] - box[0]
         height = box[3] - box[1]
@@ -773,7 +774,7 @@ class ShapeToPilExport(ShapeExport):
         x, y = text_coords['x'], text_coords['y']
 
         r, g, b, a = self.get_rgba_int(stroke_color)
-        font = self.get_font(font_size)
+        font = get_font(font_size)
         box = font.getbbox(text)
         txt_w = box[2] - box[0]
         box = font.getbbox("Mg")  # height including acsenders & descenders
@@ -2240,12 +2241,17 @@ class FigureExport(object):
             if width * height > max_sizes[0] * max_sizes[1]:
                 self.errors.append(
                     f"Failed to render image {image.name} (ID: {image.id}):" +
-                    f" Smallest pyramid resolution is too large to render:" +
+                    " Smallest pyramid resolution is too large to render:" +
                     f" {width} x {height} > {max_sizes[0]} x {max_sizes[1]}")
-                # return a placeholder PIL Image with "failed to render" message 
-                pil_img = Image.new("RGBA", (width//10, height//10), (221, 221, 221, 255))
+                # return a placeholder PIL Image with "failed to render" text
+                ph_width = 400
+                ph_height = int(ph_width * (height / width))
+                font = get_font(30)
+                pil_img = Image.new("RGBA", (ph_width, ph_height),
+                                    (221, 221, 221, 255))
                 draw = ImageDraw.Draw(pil_img)
-                draw.text((10, 10), "Failed to render", fill=(255, 0, 0, 255))
+                draw.text((10, 10), "Failed to render",
+                          fill=(255, 0, 0, 255), font=font)
                 return pil_img
 
             try:
@@ -2686,7 +2692,8 @@ class FigureExport(object):
         page_y = page_height - self.margin
         print("ERRORS", self.errors)
         for msg in self.errors:
-            page_y = self.add_para_with_thumb("Error: " + msg, page_y, style=style_error)
+            page_y = self.add_para_with_thumb("Error: " + msg,
+                                              page_y, style=style_error)
 
         # Start adding at the top, update page_y as we add paragraphs
         page_y = self.add_para_with_thumb(figure_name, page_y, style=style_h)
@@ -2976,40 +2983,12 @@ class TiffExport(FigureExport):
     def __init__(self, conn, script_params, export_images=None):
 
         super(TiffExport, self).__init__(conn, script_params, export_images)
-
-        if omero_installed:
-            from omero.gateway import THISPATH
-            self.FONTPATH = os.path.join(THISPATH, "pilfonts")
-        else:
-            # get location of this script... /pilfonts
-            this_path = os.path.dirname(os.path.abspath(__file__))
-            self.FONTPATH = os.path.join(this_path, "pilfonts")
         self.ns = "omero.web.figure.tiff"
         self.mimetype = "image/tiff"
 
     def add_rois(self, panel, page):
         """ TIFF export doesn't add ROIs to page (does it to panel)"""
         pass
-
-    def get_font(self, fontsize, bold=False, italics=False):
-        """ Try to load font from known location in OMERO """
-        font_name = "FreeSans.ttf"
-        if bold and italics:
-            font_name = "FreeSansBoldOblique.ttf"
-        elif bold:
-            font_name = "FreeSansBold.ttf"
-        elif italics:
-            font_name = "FreeSansOblique.ttf"
-        path_to_font = os.path.join(self.FONTPATH, font_name)
-        try:
-            font = ImageFont.truetype(path_to_font, fontsize)
-        except Exception:
-            try:
-                font_path = os.path.join(self.FONTPATH, "B24.pil")
-                font = ImageFont.load(font_path)
-            except Exception:
-                font = ImageFont.load_default()
-        return font
 
     def get_figure_file_ext(self):
         return "tiff"
@@ -3123,7 +3102,7 @@ class TiffExport(FigureExport):
         widths = []
         heights = []
         for t in tokens:
-            font = self.get_font(fontsize, t['bold'], t['italics'])
+            font = get_font(fontsize, t['bold'], t['italics'])
             box = font.getbbox(t['text'])
             txt_w = box[2] - box[0]
             txt_h = box[3] - box[1]
@@ -3138,7 +3117,7 @@ class TiffExport(FigureExport):
 
         w = 0
         for t in tokens:
-            font = self.get_font(fontsize, t['bold'], t['italics'])
+            font = get_font(fontsize, t['bold'], t['italics'])
             box = font.getbbox(t['text'])
             txt_w = box[2] - box[0]
             txt_h = box[3] - box[1]

--- a/omero_figure/settings.py
+++ b/omero_figure/settings.py
@@ -23,6 +23,7 @@
 
 from . import utils
 import warnings
+from omeroweb.utils import leave_none_unset
 
 warnings.warn("Deprecated. utils.__version__", DeprecationWarning)
 OMERO_FIGURE_VERSION = utils.__version__
@@ -34,5 +35,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
         10,
         int,
         "Maximum number of active channels allowed in Figure"
+    ],
+
+    "omero.figure.max_panel_pixels": [
+        "MAX_PANEL_PIXELS",
+        None,
+        leave_none_unset,
+        ("Maximum number of pixels allowed for the rendering engine."
+         "Default is conn.getMaxPlaneSize() approx 3k x 3k")
     ],
 }

--- a/omero_figure/views.py
+++ b/omero_figure/views.py
@@ -699,6 +699,10 @@ def make_web_figure(request, conn=None, **kwargs):
         'Export_Option': wrap(str(export_option)),
         'Webclient_URI': wrap(webclient_uri)}
 
+    if hasattr(figure_settings, 'MAX_PANEL_PIXELS'):
+        max_panel_pixels = figure_settings.MAX_PANEL_PIXELS
+        input_map['Max_Panel_Pixels'] = rlong(int(max_panel_pixels))
+
     # If the figure has been saved, construct URL to it.
     figure_dict = json.loads(figure_json)
     if 'fileId' in figure_dict:


### PR DESCRIPTION
Follow-up of #700.

With the fix of the logic for picking zoom levels in #700, it is possible that the export script attempts to render a region larger than `max plane size` (`omero.pixeldata.max_plane_width * omero.pixeldata.max_plane_height`) if the image's smallest pyramid resolution is still quite large.

This PR adds an extra check to make sure the chosen resolution doesn't exceed that size limit before we try to render.

If it does, we simply skip the addition of that panel to the figure and the rest of the figure should be exported as normal.

To test:

 - create / find big image with few resolutions (as described in #700)
 - Add image to figure (along with other images) and export the figure
 - The offending image should be skipped and the rest of the figure exported as normal